### PR TITLE
Fix/improve octatonic scales

### DIFF
--- a/src/main/java/de/mossgrabers/framework/scale/Scale.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scale.java
@@ -117,7 +117,21 @@ public enum Scale
         5,
         6,
         8,
-        9
+        9,
+	11
+    }),
+
+    /** The Half-whole scale. */
+    HALF_WHOLE("Half-whole", new int []
+    {
+        0,
+        1,
+        3,
+        4,
+        6,
+        7,
+        9,
+	10
     }),
 
     /** The Whole Tone scale. */


### PR DESCRIPTION
I'm not a music theorist, but I think this is correct based upon Push 1's behavior with whole-half (scale includes 1 semitone below root), and then this also adds the half-whole, which is very similar and which googling around led me to believe is actually slightly more popular (although they're both not that common).

* Fixed: Correct whole-half scale
* New: Add half-whole scale

Tested to work on Bitwig 2.1.3 and a Push 1.

I also don't know if you prefer changes to be contributed via GitHub PRs or some other way, please let me know if so.