### PR TITLE
Enable and document building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # DrivenByMoss
 Bitwig Studio extensions to support several controllers
+
+### Building and Installing the extension
+
+Users should download and install the version from the
+[main site](http://www.mossgrabers.de/Software/Bitwig/Bitwig.html).
+These directions are for developers to test changes prior to release.
+
+1. Install Maven and dependences, either [from here](https://maven.apache.org/install.html)
+or if on Linux, using the distro package manager, e.g. `yum install maven` or
+`apt-get install maven`.
+1. Run `mvn package` in this repo's root.
+1. cd to `target` and rename `DrivenByMoss-LOCAL-<number>.jar` to
+`DrivenByMoss.bwextension`.
+1. Follow [installation instructions](https://github.com/git-moss/DrivenByMoss/wiki/Installation)
+for further steps.

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -58,6 +58,13 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>bitwig</id>
+      <name>Bitwig Maven Repository</name>
+      <url>https://maven.bitwig.com</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>com.bitwig</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,20 +10,20 @@
 
 	<!-- https://mvnrepository.com/artifact/com.illposed.osc/javaosc-core -->
 
+	<repositories>
+	  <repository>
+            <id>bitwig</id>
+            <name>Bitwig Maven Repository</name>
+            <url>https://maven.bitwig.com</url>
+	  </repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.illposed.osc</groupId>
 			<artifactId>javaosc-core</artifactId>
 			<version>0.4</version>
 		</dependency>
-
-<!--	<repositories>
-       <repository>
-         <id>bitwig</id>
-         <name>Bitwig Maven Repository</name>
-         <url>https://maven.bitwig.com</url>
-       </repository>
-   </repositories> -->
 
 		<dependency>
 			<groupId>com.bitwig</groupId>


### PR DESCRIPTION
The first commit is changes I needed to make to get the extension to build. It just took moving and uncommenting in the pom to re-enable, any reason not to make this change?

The second commit adds some documentation on what it takes to build the extension, while also pointing non-developer users to existing documentation and download sites as much as possible. Please let me know if this is ok, or changes or additions you'd like -- I'm not a regular Maven or Java user.

Much thanks!