### PR TITLE
added /device/page/selected/name

### DIFF
--- a/src/main/java/de/mossgrabers/osc/protocol/OSCWriter.java
+++ b/src/main/java/de/mossgrabers/osc/protocol/OSCWriter.java
@@ -272,7 +272,11 @@ public class OSCWriter
         for (int i = 0; i < 8; i++)
         {
             final int oneplus = i + 1;
-            this.sendOSC (deviceAddress + "page/" + oneplus + "/", i < parameterPageNames.length ? parameterPageNames[i] : "", dump);
+            String parameterPageName = i < parameterPageNames.length ? parameterPageNames[i] : "";
+            this.sendOSC (deviceAddress + "page/" + oneplus + "/", parameterPageName, dump);
+            if (i == device.getSelectedParameterPage()) {
+                this.sendOSC (deviceAddress + "page/selected/name", parameterPageName, dump);
+            }
         }
     }
 


### PR DESCRIPTION
Kinda hard in open stage control to combine 2 calls into one label. So I created this entry.

Are the names to change to device pages badly chosen?
It is now:
/device/param/+
/device/param/-

But /device/page/selected .... as well.
Bitwig terminology seems to be about 'device page'.