### PR TITLE
BeatstepPro: make the 'mode change' keys actually change the mode

### DIFF
--- a/src/main/java/de/mossgrabers/controller/beatstep/view/ShiftView.java
+++ b/src/main/java/de/mossgrabers/controller/beatstep/view/ShiftView.java
@@ -134,6 +134,7 @@ public class ShiftView extends AbstractView<BeatstepControlSurface, BeatstepConf
                 final Integer viewId = Integer.valueOf (viewIndex);
                 viewManager.setPreviousView (viewId);
                 view = viewManager.getView (viewId);
+                viewManager.setActiveView(viewId);
                 this.surface.getDisplay ().notify (view.getName ());
                 break;
         }


### PR DESCRIPTION
Using step keys 9-16 does not actually change the mode - regardless of what key is hit, 'Track' mode remains active.

Please review my fix and merge.
