### PR TITLE
Toggle rec arm when pressing first row button on selected track

### DIFF
--- a/src/main/java/de/mossgrabers/controller/push/mode/track/AbstractTrackMode.java
+++ b/src/main/java/de/mossgrabers/controller/push/mode/track/AbstractTrackMode.java
@@ -1,4 +1,4 @@
-// Written by Jürgen Moßgraber - mossgrabers.de
+﻿// Written by Jürgen Moßgraber - mossgrabers.de
 // (c) 2017-2018
 // Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
 
@@ -95,12 +95,11 @@ public abstract class AbstractTrackMode extends BaseMode
             final ITrack selTrack = tb.getSelectedItem ();
             if (selTrack != null && selTrack.getIndex () == index)
             {
-                // If it is a group display child channels of group, otherwise jump into device
-                // mode
+                // If it is a group display child channels of group, otherwise toggle rec arm
                 if (selTrack.isGroup ())
                     tb.selectChildren ();
                 else
-                    this.surface.getViewManager ().getActiveView ().executeTriggerCommand (Commands.COMMAND_DEVICE, ButtonEvent.DOWN);
+                    track.toggleRecArm ();
             }
             else
                 track.select ();


### PR DESCRIPTION
When a track is selected, pressing the first row button will now record-arm the track, so that tracks can be armed with one hand. The original combo (rec button + track button) is still available.

The previous behaviour was that pressing the first row button switched that track to device mode. This has been replaced by the rec-arm toggle, as the device mode can easily be accessed by the device button on push.