### PR TITLE
Initalize Views on Launchpad setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ last-build.bin
 fileHashes.lock
 /.settings/org.eclipse.m2e.core.prefs
 /.settings/org.sonarlint.eclipse.core.prefs
+/.idea/
+.idea/
+DrivenByMoss (1).iml
+/DrivenByMoss (2).iml
+/DrivenByMoss (2).iml
+src/main/java/target/

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -121,6 +121,7 @@
     </dependency>
   </dependencies>
   <properties>
+    <bitwig.extension.directory>/Users/saile/Documents/Bitwig Studio/Extensions</bitwig.extension.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<bitwig.extension.directory>/Users/saile/Documents/Bitwig Studio/Extensions</bitwig.extension.directory>
 	</properties>
 
 	<repositories>

--- a/src/main/java/de/mossgrabers/controller/launchpad/LaunchpadControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/launchpad/LaunchpadControllerSetup.java
@@ -112,6 +112,7 @@ public class LaunchpadControllerSetup extends AbstractControllerSetup<LaunchpadC
         LaunchpadColors.addColors (this.colorManager);
         this.valueChanger = new DefaultValueChanger (128, 1, 0.5);
         this.configuration = new LaunchpadConfiguration (this.valueChanger, isPro);
+        Views.init(host);
     }
 
 


### PR DESCRIPTION
Hi Jürgen,

note mode on a Launchpad pro was not correctly entered because the Views class was not initialised during the setup of the Launchpad. 
If you have a Push hooked up to your machine Views.init() is called during the setup of the Push. So when you are lucky and have a Push and a Launchpad everything works.

I tested the fix for the last day and haven't found any issues. 

Cheers,

Jochen