### PR TITLE
Added minimal support for channelized OSC messages

### DIFF
--- a/src/main/java/de/mossgrabers/controller/osc/module/BrowserModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/BrowserModule.java
@@ -50,7 +50,7 @@ public class BrowserModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/GlobalModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/GlobalModule.java
@@ -48,7 +48,7 @@ public class GlobalModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/IModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/IModule.java
@@ -36,7 +36,7 @@ public interface IModule
      * @throws UnknownCommandException Unknown command
      * @throws MissingCommandException Missing sub-command
      */
-    void execute (String command, LinkedList<String> path, Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException;
+    void execute (String command, LinkedList<String> path, Object value, Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException;
 
 
     /**

--- a/src/main/java/de/mossgrabers/controller/osc/module/LayoutModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/LayoutModule.java
@@ -53,7 +53,7 @@ public class LayoutModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/MarkerModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/MarkerModule.java
@@ -49,7 +49,7 @@ public class MarkerModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         if (!"marker".equals (command))
             throw new UnknownCommandException (command);

--- a/src/main/java/de/mossgrabers/controller/osc/module/MidiModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/MidiModule.java
@@ -62,7 +62,7 @@ public class MidiModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/ProjectModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/ProjectModule.java
@@ -48,7 +48,7 @@ public class ProjectModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/SceneModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/SceneModule.java
@@ -49,7 +49,7 @@ public class SceneModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/TrackModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/TrackModule.java
@@ -68,7 +68,7 @@ public class TrackModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/TransportModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/TransportModule.java
@@ -77,7 +77,7 @@ public class TransportModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/module/UserModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/UserModule.java
@@ -49,7 +49,7 @@ public class UserModule extends AbstractModule
 
     /** {@inheritDoc} */
     @Override
-    public void execute (final String command, final LinkedList<String> path, final Object value) throws IllegalParameterException, UnknownCommandException, MissingCommandException
+    public void execute (final String command, final LinkedList<String> path, final Object value, final Object... voice) throws IllegalParameterException, UnknownCommandException, MissingCommandException
     {
         switch (command)
         {

--- a/src/main/java/de/mossgrabers/controller/osc/protocol/OSCParser.java
+++ b/src/main/java/de/mossgrabers/controller/osc/protocol/OSCParser.java
@@ -76,13 +76,15 @@ public class OSCParser extends AbstractOpenSoundControlParser
         }
 
         final Object [] values = message.getValues ();
+        
         final Object value = values == null || values.length == 0 ? null : values[0];
+        final Object voice = values == null || values.length == 1 ? null : values[1];
         try
         {
             final IModule module = this.modules.get (command);
             if (module == null)
                 throw new UnknownCommandException (command);
-            module.execute (command, oscParts, value);
+            module.execute (command, oscParts, value, voice);
         }
         catch (final IllegalParameterException ex)
         {


### PR DESCRIPTION
Some OSC clients like f.e. TC-Data (https://bitshapesoftware.com/instruments/tc-data/)
have the concept of OSC channels. These channels are used like MIDI channels.

One example could be the first touching finger gets channel 1, the second channel 2 and so on.

An OSC message looks like this:  /device/layer/1/send/1/volume [ 371.29318, 1.0 ]

The second value in the data array is the channel (0.0 is first channel).

The idea is to re-write the layer id with the channel. Then in Bitwig the different fingers/channels
in TC-Data can be programmed with "Map to controller key" as different entities in global user macros.

A better solution would be to fully integrate the concept of the OSC result data array for different purposes.
Also handling of unique OSC strings like /global/metaparameter/{1-128} would be cleaner than to misuse the
/device/layer/. .. string for mapped user parameters.