### PR TITLE
Novation Launchkey mini Mk3 :: onGridNoteLongPress :: stop clip

### DIFF
--- a/src/main/java/de/mossgrabers/controller/launchkey/controller/LaunchkeyMiniMk3ControlSurface.java
+++ b/src/main/java/de/mossgrabers/controller/launchkey/controller/LaunchkeyMiniMk3ControlSurface.java
@@ -139,9 +139,9 @@ public class LaunchkeyMiniMk3ControlSurface extends AbstractControlSurface<Launc
     {
         boolean isInc = this.lastPrgChange - data1 < 0;
         if (this.lastPrgChange == 127 && data1 == 0)
-            isInc = true;
-        else if (this.lastPrgChange == 0 && data1 == 127)
             isInc = false;
+        else if (this.lastPrgChange == 0 && data1 == 127)
+            isInc = true;
         this.lastPrgChange = data1;
         this.pageAdjuster.execute (isInc ? 1 : -1);
     }

--- a/src/main/java/de/mossgrabers/controller/launchkey/controller/LaunchkeyMiniMk3ControlSurface.java
+++ b/src/main/java/de/mossgrabers/controller/launchkey/controller/LaunchkeyMiniMk3ControlSurface.java
@@ -139,11 +139,11 @@ public class LaunchkeyMiniMk3ControlSurface extends AbstractControlSurface<Launc
     {
         boolean isInc = this.lastPrgChange - data1 < 0;
         if (this.lastPrgChange == 127 && data1 == 0)
-            isInc = false;
-        else if (this.lastPrgChange == 0 && data1 == 127)
             isInc = true;
+        else if (this.lastPrgChange == 0 && data1 == 127)
+            isInc = false;
         this.lastPrgChange = data1;
-        this.pageAdjuster.execute (isInc ? 1 : -1);
+        this.pageAdjuster.execute (isInc ? -1 : 1);
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/launchkey/view/SessionView.java
+++ b/src/main/java/de/mossgrabers/controller/launchkey/view/SessionView.java
@@ -14,6 +14,7 @@ import de.mossgrabers.framework.daw.ISceneBank;
 import de.mossgrabers.framework.daw.ITrackBank;
 import de.mossgrabers.framework.daw.data.IScene;
 import de.mossgrabers.framework.daw.data.ITrack;
+import de.mossgrabers.framework.daw.data.ISlot;
 import de.mossgrabers.framework.mode.Modes;
 import de.mossgrabers.framework.utils.ButtonEvent;
 import de.mossgrabers.framework.utils.Pair;
@@ -181,10 +182,63 @@ public class SessionView extends AbstractSessionView<LaunchkeyMiniMk3ControlSurf
 			// we have a padmode selected and longpressing on a second row pad, do nothing
 			return;
 		}else{
-			// long press stop the track
+			// long press stop the track, TODO do it with scene button also. How ??
+
 			final ITrack track = this.model.getCurrentTrackBank ().getItem (column);
-			track.stop ();
+			final ISlot slot = track.getSlotBank ().getItem (row);
+
+		
+
+			if (slot.hasContent ())
+			{
+				track.stop ();
+			}else{
+				if (!slot.isRecording ()){
+					// turn off recArms of every track, and recArm the selected one.
+					
+					final ITrackBank bank = this.model.getTrackBank ();
+
+					int pageSize = bank.getPageSize();
+
+					// TODO disabling for all tracks not just in the pageSize
+					// int scrollPosition = bank.getScrollPosition();
+					// bank.scrollTo(0);
+					// for(int i=0; i< bank.getItemCount(); i++){
+					// 	bank.getItem (i%pageSize).setRecArm(i == column);
+					// 	if(!bank.canScrollForwards()){
+					// 		bank.scrollForwards();
+					// 	}
+					// }
+					// bank.scrollTo(scrollPosition);
+
+
+					for(int i=0; i< pageSize; i++){
+						bank.getItem (i).setRecArm(i == column);
+					}
+
+					track.setRecArm(true);
+					slot.record ();
+
+				}
+			}
 		}
+
+			/* TODO : if scene empty, launch record
+			final ISceneBank sceneBank = this.model.getCurrentTrackBank ().getSceneBank ();
+			getSlotBank
+	
+			final ISlot selectedSlot = this.model.getSelectedSlot ();
+			if (selectedSlot != null)
+				selectedSlot.record ();
+	
+			if (slot.hasContent ())
+			{
+				slot.stop ();
+				return;
+			}else{
+				slot.record ();
+			}
+	*/
 	}
 	
 

--- a/src/main/java/de/mossgrabers/controller/launchkey/view/SessionView.java
+++ b/src/main/java/de/mossgrabers/controller/launchkey/view/SessionView.java
@@ -164,7 +164,29 @@ public class SessionView extends AbstractSessionView<LaunchkeyMiniMk3ControlSurf
             super.onGridNote (note, velocity);
         else
             this.handleFirstRowModes (padPos.getKey ().intValue ());
-    }
+	}
+	
+	/** {@inheritDoc} */
+	@Override
+	public void onGridNoteLongPress (final int note)
+	{
+		final SessionView view = (SessionView) this.surface.getViewManager ().getView (Views.SESSION);
+		final Modes padMode = view.getPadMode ();
+
+		final Pair<Integer, Integer> padPos = this.getPad (note);
+		final int column = padPos.getKey ().intValue ();
+		final int row = padPos.getValue ().intValue ();
+		
+		if(padMode != null && row == -1){
+			// we have a padmode selected and longpressing on a second row pad, do nothing
+			return;
+		}else{
+			// long press stop the track
+			final ITrack track = this.model.getCurrentTrackBank ().getItem (column);
+			track.stop ();
+		}
+	}
+	
 
 
     /** {@inheritDoc} */

--- a/src/main/java/de/mossgrabers/framework/daw/IBank.java
+++ b/src/main/java/de/mossgrabers/framework/daw/IBank.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * Interface to a bank. A bank provides a view to a number of items split into pages. A page
- * contains a given numbner of items.
+ * contains a given number of items.
  *
  * @param <T> The type of the items present in the bank
  *


### PR DESCRIPTION
I am going to add (I hope) features to  **Session** mode.

Now you can longPress to stop a clip. (No need to be in stop submode ! so you can keep the 2 rows !)

TODO :  
- if clip empty, arm track and record in this clip
don't know yet how to do it in this _onGridNoteLongPress_ :
How to go from 		
 ```
         final Pair<Integer, Integer> padPos = this.getPad (note);
		final int column = padPos.getKey ().intValue ();
		final int row = padPos.getValue ().intValue ();

```
to a ISlot.record()


- find a way to quickly toggle the click (maybe in the PadModeSelectView, i use a new button)
- stop/solo/mute button with first knob would change tempo
- stop/solo/mute button with second knob would change click volume like in this script for the mk2 : 
https://youtu.be/1QCygMhagwU?t=422