### PR TITLE
navigatedIntoTrackGroup & SL MkIII Group Entry/Exit

### DIFF
--- a/src/main/java/de/mossgrabers/bitwig/framework/daw/ApplicationImpl.java
+++ b/src/main/java/de/mossgrabers/bitwig/framework/daw/ApplicationImpl.java
@@ -11,6 +11,7 @@ import de.mossgrabers.framework.daw.constants.RecordQuantization;
 import com.bitwig.extension.controller.api.Action;
 import com.bitwig.extension.controller.api.ActionCategory;
 import com.bitwig.extension.controller.api.Application;
+import com.bitwig.extension.controller.api.Track;
 
 
 /**
@@ -307,6 +308,23 @@ public class ApplicationImpl implements IApplication
         this.application.escape ();
     }
 
+    /**
+     * Changes the Document's Track Group.
+     *
+     * @param groupTrack Current project's engine active.
+     */
+    public void navigateIntoTrackGroup (Track groupTrack)
+    {
+        this.application.navigateIntoTrackGroup (groupTrack);
+    }
+
+    /**
+     * If inside a Track Group, changes the Document's Track Group to its Parent.
+     */
+    public void navigateToParentTrackGroup ()
+    {
+        this.application.navigateToParentTrackGroup ();
+    }
 
     /** {@inheritDoc} */
     @Override

--- a/src/main/java/de/mossgrabers/bitwig/framework/daw/data/TrackImpl.java
+++ b/src/main/java/de/mossgrabers/bitwig/framework/daw/data/TrackImpl.java
@@ -416,6 +416,22 @@ public class TrackImpl extends ChannelImpl implements ITrack
     }
 
 
+    /** {@inheritDoc} */
+    @Override
+    public void scopeTo ()
+    {
+        this.application.navigateIntoTrackGroup (this.track);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void scopeToParent ()
+    {
+        this.application.navigateToParentTrackGroup ();
+    }
+
+
     /**
      * Add a note observer.
      *

--- a/src/main/java/de/mossgrabers/controller/slmkiii/mode/track/AbstractTrackMode.java
+++ b/src/main/java/de/mossgrabers/controller/slmkiii/mode/track/AbstractTrackMode.java
@@ -80,8 +80,30 @@ public abstract class AbstractTrackMode extends BaseMode
     @Override
     public void onButton (final int row, final int index, final ButtonEvent event)
     {
-        if (event != ButtonEvent.UP || row != 0)
+        if (event == ButtonEvent.DOWN || row != 0)
             return;
+
+        final ITrackBank tb = this.model.getCurrentTrackBank ();
+        final ITrack track = tb.getItem (index);
+
+        // Long-held attempts Group Entry/Exit
+        if (event == ButtonEvent.LONG)
+        {
+            if (track.isGroup ())
+            {
+                track.enter ();
+                track.scopeTo ();
+                this.surface.setTriggerConsumed (ButtonID.get (ButtonID.ROW1_1, index));
+            }
+            else if (tb.hasParent ())
+            {
+                track.scopeToParent ();
+                tb.selectParent ();
+                this.surface.setTriggerConsumed (ButtonID.get (ButtonID.ROW1_1, index));
+            }
+
+            return;
+        }
 
         // Combination with Shift
         if (this.surface.isShiftPressed ())
@@ -97,9 +119,6 @@ public abstract class AbstractTrackMode extends BaseMode
             this.surface.setTriggerConsumed (ButtonID.ARROW_DOWN);
             return;
         }
-
-        final ITrackBank tb = this.model.getCurrentTrackBank ();
-        final ITrack track = tb.getItem (index);
 
         // Combination with Duplicate
         if (this.surface.isPressed (ButtonID.DUPLICATE))

--- a/src/main/java/de/mossgrabers/framework/daw/data/ITrack.java
+++ b/src/main/java/de/mossgrabers/framework/daw/data/ITrack.java
@@ -197,6 +197,18 @@ public interface ITrack extends IChannel
 
 
     /**
+     * Change the Document's Scope to this Track (if it's a Group).
+     */
+    void scopeTo ();
+
+
+    /**
+     * Change the Document's Scope to this Track's Parent (if it's not the root).
+     */
+    void scopeToParent ();
+
+
+    /**
      * Test if record quantization for note lengths is enabled.
      *
      * @return True if enabled

--- a/src/main/java/de/mossgrabers/framework/daw/data/empty/EmptyTrack.java
+++ b/src/main/java/de/mossgrabers/framework/daw/data/empty/EmptyTrack.java
@@ -208,6 +208,22 @@ public class EmptyTrack extends EmptyChannel implements ITrack
 
     /** {@inheritDoc} */
     @Override
+    public void scopeTo ()
+    {
+        // Intentionally empty
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void scopeToParent ()
+    {
+        // Intentionally empty
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
     public ISlotBank getSlotBank ()
     {
         return EmptySlotBank.INSTANCE;


### PR DESCRIPTION
Greetings, and of course I must first thank you for all of your efforts. I didn't see any contribution guidelines, so I hope this is welcome. I also hope this is in the spirit of your long-term desires, so for the implementation I am completely open to changes.

First commit is just about the framework code. You might know that [in Bitwig's API](https://github.com/teotigraphix/Framework4Bitwig/issues/127) these functions are at the Application level and they take a Track as an input. Given the access levels of your abstractions, it made sense to me to include it at the Application-level too (even though it could easily be refactored into the Track alone), but access it from the Track (it needs a Track as an input, and arguably the user is very Track-focused in these contexts).

The second commit is just for the SL MkIII since that's the only relevant controller I own and I didn't want to go too far without you. I went with a "long press a group to enter, long press a non-group to exit" approach, but of course I'm open to ideas here. I wondered about Shifting the Up/Down on the Right-side, and even a separate Track/Group mode. This was pretty quick workflow-wise and the first option I imagined when I was watching your videos.

I tested a few scenarios once I got this working. Notably, I _thought_ that selecting a Track twice would swap to the Device mode for that track, but that isn't working right now. That _might_ be a bug with 11.5 since I was not on this version until I checked it out and built it locally, and this happens on master too. Or, it might be a problem with my local build process.

* Long-Press; Selected, Unselected; deep, shallow; Tracks that are Groups: it's entered and the first Track is selected
* Long-Press; Selected, Unselected, deep, shallow, empty space/column: it's exited to the next-level-up and the exited-Group is selected
* No level above; nested Track/Group selected; the selection moves higher in the hierarchy
* No level above; top-level-selection: nothing happens
* All three Track modes working the same way