### PR TITLE
Disabled changing to pad/keyboard configuration when on maschine mk3 step sequencer

### DIFF
--- a/src/main/java/de/mossgrabers/controller/maschine/command/trigger/KeyboardCommand.java
+++ b/src/main/java/de/mossgrabers/controller/maschine/command/trigger/KeyboardCommand.java
@@ -6,6 +6,7 @@ package de.mossgrabers.controller.maschine.command.trigger;
 
 import de.mossgrabers.controller.maschine.MaschineConfiguration;
 import de.mossgrabers.controller.maschine.controller.MaschineControlSurface;
+import de.mossgrabers.controller.maschine.view.DrumView;
 import de.mossgrabers.controller.maschine.view.PlayView;
 import de.mossgrabers.framework.command.core.AbstractTriggerCommand;
 import de.mossgrabers.framework.daw.IModel;
@@ -46,14 +47,16 @@ public class KeyboardCommand extends AbstractTriggerCommand<MaschineControlSurfa
         final ViewManager viewManager = this.surface.getViewManager ();
         if (viewManager.isActive (Views.PLAY))
         {
-            if (!this.surface.getMaschine ().hasMCUDisplay ())
-                ((PlayView) viewManager.get (Views.PLAY)).toggleShifted ();
+            if (!((DrumView) viewManager.get (Views.DRUM)).isSequencerVisible()) {
+                if (!this.surface.getMaschine().hasMCUDisplay())
+                    ((PlayView) viewManager.get(Views.PLAY)).toggleShifted();
 
-            final ModeManager modeManager = this.surface.getModeManager ();
-            if (modeManager.isActive (Modes.SCALES))
-                modeManager.restore ();
-            else
-                modeManager.setTemporary (Modes.SCALES);
+                final ModeManager modeManager = this.surface.getModeManager();
+                if (modeManager.isActive(Modes.SCALES))
+                    modeManager.restore();
+                else
+                    modeManager.setTemporary(Modes.SCALES);
+            }
         }
         else
             viewManager.setActive (Views.PLAY);

--- a/src/main/java/de/mossgrabers/controller/maschine/command/trigger/PadModeCommand.java
+++ b/src/main/java/de/mossgrabers/controller/maschine/command/trigger/PadModeCommand.java
@@ -45,14 +45,16 @@ public class PadModeCommand extends AbstractTriggerCommand<MaschineControlSurfac
         final ViewManager viewManager = this.surface.getViewManager ();
         if (viewManager.isActive (Views.DRUM))
         {
-            if (!this.surface.getMaschine ().hasMCUDisplay ())
-                ((DrumView) viewManager.get (Views.DRUM)).toggleShifted ();
+            if (!((DrumView) viewManager.get (Views.DRUM)).isSequencerVisible()) {
+                if (!this.surface.getMaschine().hasMCUDisplay())
+                    ((DrumView) viewManager.get(Views.DRUM)).toggleShifted();
 
-            final ModeManager modeManager = this.surface.getModeManager ();
-            if (modeManager.isActive (Modes.PLAY_OPTIONS))
-                modeManager.restore ();
-            else
-                modeManager.setActive (Modes.PLAY_OPTIONS);
+                final ModeManager modeManager = this.surface.getModeManager();
+                if (modeManager.isActive(Modes.PLAY_OPTIONS))
+                    modeManager.restore();
+                else
+                    modeManager.setActive(Modes.PLAY_OPTIONS);
+            }
         }
         else
             viewManager.setActive (Views.DRUM);


### PR DESCRIPTION
While I was testing my new Maschine Mikro mk3(got it a day ago just because of this project) with this script. I've realized that when using the step sequencer on pad mode or keyboard it's possible to change the pad mode/keyboard to its configuration page. This might be the intended behavior, but changing the views on unseen pages seemed unintuitive.

I don't know much java, so this is the simplest solution I could find. 