### PR TITLE
Launchkey Mini MK3 additional device and browser views

### DIFF
--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
@@ -179,6 +179,7 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
         viewManager.register (Views.DRUM, new DeviceView (surface, this.model));
         viewManager.register (Views.PLAY, new UserPadView (surface, this.model));
         viewManager.register (Views.SHIFT, new DrumConfigView (surface, this.model));
+        viewManager.register (Views.BROWSER, new BrowserView (surface, this.model));
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
@@ -6,11 +6,7 @@ package de.mossgrabers.controller.novation.launchkey.mini;
 
 import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ColorManager;
 import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ControlSurface;
-import de.mossgrabers.controller.novation.launchkey.mini.view.DrumConfigView;
-import de.mossgrabers.controller.novation.launchkey.mini.view.DrumView;
-import de.mossgrabers.controller.novation.launchkey.mini.view.PadModeSelectView;
-import de.mossgrabers.controller.novation.launchkey.mini.view.SessionView;
-import de.mossgrabers.controller.novation.launchkey.mini.view.UserPadView;
+import de.mossgrabers.controller.novation.launchkey.mini.view.*;
 import de.mossgrabers.framework.MVHelper;
 import de.mossgrabers.framework.command.core.NopCommand;
 import de.mossgrabers.framework.command.trigger.Direction;
@@ -178,7 +174,7 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
         final LaunchkeyMiniMk3ControlSurface surface = this.getSurface ();
         final ViewManager viewManager = surface.getViewManager ();
 
-        viewManager.register (Views.SESSION, new SessionView (surface, this.model));
+        viewManager.register (Views.SESSION, new DeviceView (surface, this.model));
         viewManager.register (Views.CONTROL, new PadModeSelectView (surface, this.model));
         viewManager.register (Views.DRUM, new DrumView (surface, this.model));
         viewManager.register (Views.PLAY, new UserPadView (surface, this.model));
@@ -210,7 +206,7 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
         this.addButton (ButtonID.SCENE2, "Scene 2", new ViewButtonCommand<> (ButtonID.SCENE2, surface), LaunchkeyMiniMk3ControlSurface.LAUNCHKEY_SCENE2, new FeatureGroupButtonColorSupplier (viewManager, ButtonID.SCENE2));
 
         // View selection with Pads in Shift mode
-        this.createViewButton (ButtonID.ROW2_1, OutputID.LED_RING1, "Session", Views.SESSION, LaunchkeyMiniMk3ControlSurface.PAD_MODE_SESSION);
+        this.createViewButton (ButtonID.ROW2_1, OutputID.LED_RING1, "Device", Views.SESSION, LaunchkeyMiniMk3ControlSurface.PAD_MODE_SESSION);
         this.createViewButton (ButtonID.ROW2_2, OutputID.LED_RING2, "Drum", Views.DRUM, LaunchkeyMiniMk3ControlSurface.PAD_MODE_DRUM);
         this.createViewButton (ButtonID.ROW2_3, OutputID.LED_RING3, "Custom", Views.PLAY, LaunchkeyMiniMk3ControlSurface.PAD_MODE_CUSTOM);
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
@@ -400,13 +400,16 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
                 break;
 
             case DEVICE_PARAMS:
-                final ICursorDevice cursorDevice = this.model.getCursorDevice ();
-                final IParameterBank parameterBank = cursorDevice.getParameterBank ();
+                // Insert device before or after current device
                 if (value > 0)
-                    parameterBank.selectNextItem ();
-                else
-                    parameterBank.selectPreviousItem ();
-                this.mvHelper.notifySelectedParameterPage ();
+                {
+                    this.getSurface().getViewManager().setActive(Views.BROWSER);
+                    this.model.getBrowser().insertAfterCursorDevice();
+                }
+                else {
+                    this.getSurface().getViewManager ().setActive (Views.BROWSER);
+                    this.model.getBrowser().insertBeforeCursorDevice();
+                }
                 break;
 
             default:

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
@@ -174,9 +174,9 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
         final LaunchkeyMiniMk3ControlSurface surface = this.getSurface ();
         final ViewManager viewManager = surface.getViewManager ();
 
-        viewManager.register (Views.SESSION, new DeviceView (surface, this.model));
+        viewManager.register (Views.SESSION, new SessionView (surface, this.model));
         viewManager.register (Views.CONTROL, new PadModeSelectView (surface, this.model));
-        viewManager.register (Views.DRUM, new DrumView (surface, this.model));
+        viewManager.register (Views.DRUM, new DeviceView (surface, this.model));
         viewManager.register (Views.PLAY, new UserPadView (surface, this.model));
         viewManager.register (Views.SHIFT, new DrumConfigView (surface, this.model));
     }
@@ -206,8 +206,8 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
         this.addButton (ButtonID.SCENE2, "Scene 2", new ViewButtonCommand<> (ButtonID.SCENE2, surface), LaunchkeyMiniMk3ControlSurface.LAUNCHKEY_SCENE2, new FeatureGroupButtonColorSupplier (viewManager, ButtonID.SCENE2));
 
         // View selection with Pads in Shift mode
-        this.createViewButton (ButtonID.ROW2_1, OutputID.LED_RING1, "Device", Views.SESSION, LaunchkeyMiniMk3ControlSurface.PAD_MODE_SESSION);
-        this.createViewButton (ButtonID.ROW2_2, OutputID.LED_RING2, "Drum", Views.DRUM, LaunchkeyMiniMk3ControlSurface.PAD_MODE_DRUM);
+        this.createViewButton (ButtonID.ROW2_1, OutputID.LED_RING1, "Session", Views.SESSION, LaunchkeyMiniMk3ControlSurface.PAD_MODE_SESSION);
+        this.createViewButton (ButtonID.ROW2_2, OutputID.LED_RING2, "Device", Views.DRUM, LaunchkeyMiniMk3ControlSurface.PAD_MODE_DRUM);
         this.createViewButton (ButtonID.ROW2_3, OutputID.LED_RING3, "Custom", Views.PLAY, LaunchkeyMiniMk3ControlSurface.PAD_MODE_CUSTOM);
 
         // Knob mode selection with Pads in Shift mode

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/LaunchkeyMiniMk3ControllerSetup.java
@@ -372,11 +372,11 @@ public class LaunchkeyMiniMk3ControllerSetup extends AbstractControllerSetup<Lau
 
         surface.setLaunchpadToDAW (true);
 
-        surface.getPadGrid ().setView (Views.SESSION);
-        surface.getViewManager ().setActive (Views.SESSION);
-        surface.getModeManager ().setActive (Modes.VOLUME);
-        surface.setKnobMode (LaunchkeyMiniMk3ControlSurface.KNOB_MODE_VOLUME);
-        surface.setPadMode (LaunchkeyMiniMk3ControlSurface.PAD_MODE_SESSION);
+        surface.getPadGrid ().setView (Views.DRUM);
+        surface.getViewManager ().setActive (Views.DRUM);
+        surface.getModeManager ().setActive (Modes.DEVICE_PARAMS);
+        surface.setKnobMode (LaunchkeyMiniMk3ControlSurface.KNOB_MODE_PARAMS);
+        surface.setPadMode (LaunchkeyMiniMk3ControlSurface.PAD_MODE_DRUM);
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
@@ -48,23 +48,19 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
             padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
         }
 
-        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_HI);
-        padGrid.lightEx(2, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
-        padGrid.lightEx(3, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(4, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
-        padGrid.lightEx(5, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
-        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
-
+        // Keypad
+        padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
         padGrid.lightEx(0, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
         padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(3, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
-        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
-        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+
+        // Select
+        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+
+        // Switch Tab
+        padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
+        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
     }
 
 
@@ -80,15 +76,17 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
             return;
 
         switch (note) {
-            case 36 -> browser.previousContentType();
-            case 37 -> browser.nextContentType();
-            case 38 -> {
-                browser.selectPreviousFilterColumn();
-                browser.selectPreviousFilterColumn();
-            }
-            case 39 -> browser.selectNextFilterColumn();
-            case 40 -> browser.selectPreviousFilterItem(browser.getSelectedFilterColumn().getIndex());
-            case 41 -> browser.selectNextFilterItem(browser.getSelectedFilterColumn().getIndex());
+            // Bottom left arrow keypad
+            case 36 -> this.model.getApplication().arrowKeyLeft();
+            case 37 -> this.model.getApplication().arrowKeyDown();
+            case 38 -> this.model.getApplication().arrowKeyRight();
+            case 45 -> this.model.getApplication().arrowKeyUp();
+
+            // Top Right
+            case 50 -> browser.previousContentType();
+            case 51 -> browser.nextContentType();
+
+            // Bottom Right
             case 42 -> browser.selectPreviousResult();
             case 43 -> browser.selectNextResult();
         }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
@@ -48,14 +48,23 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
             padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
         }
 
+        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_HI);
+        padGrid.lightEx(2, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
+        padGrid.lightEx(3, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(4, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
+        padGrid.lightEx(5, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
+        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
+
         padGrid.lightEx(0, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_HI);
-        padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
+        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
         padGrid.lightEx(3, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
-        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
-        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
+        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
     }
 
 
@@ -63,8 +72,40 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
     @Override
     public void onGridNote (final int note, final int velocity)
     {
-        if (note >= 36 && note <= 43)
+        if (velocity != 0)
+            return;
+
+        final IBrowser browser = this.model.getBrowser ();
+        if (!browser.isActive ())
+            return;
+
+        switch (note)
         {
+            case 36:
+                browser.previousContentType();
+                break;
+            case 37:
+                browser.nextContentType();
+                break;
+            case 38:
+                browser.selectPreviousFilterColumn();
+                browser.selectPreviousFilterColumn();
+                break;
+            case 39:
+                browser.selectNextFilterColumn();
+                break;
+            case 40:
+                browser.selectPreviousFilterItem(browser.getSelectedFilterColumn().getIndex());
+                break;
+            case 41:
+                browser.selectNextFilterItem(browser.getSelectedFilterColumn().getIndex());
+                break;
+            case 42:
+                browser.selectPreviousResult();
+                break;
+            case 43:
+                browser.selectNextResult();
+                break;
         }
     }
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
@@ -1,0 +1,96 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2017-2021
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.controller.novation.launchkey.mini.view;
+
+import de.mossgrabers.controller.novation.launchkey.mini.LaunchkeyMiniMk3Configuration;
+import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ColorManager;
+import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ControlSurface;
+import de.mossgrabers.framework.controller.ButtonID;
+import de.mossgrabers.framework.controller.grid.IPadGrid;
+import de.mossgrabers.framework.daw.IBrowser;
+import de.mossgrabers.framework.daw.IModel;
+import de.mossgrabers.framework.daw.data.ICursorDevice;
+import de.mossgrabers.framework.daw.data.bank.IDeviceBank;
+import de.mossgrabers.framework.daw.data.bank.IParameterPageBank;
+import de.mossgrabers.framework.featuregroup.AbstractView;
+import de.mossgrabers.framework.utils.ButtonEvent;
+import de.mossgrabers.framework.view.Views;
+
+
+/**
+ * The pad mode user view.
+ *
+ * @author J&uuml;rgen Mo&szlig;graber
+ */
+public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, LaunchkeyMiniMk3Configuration>
+{
+    /**
+     * Constructor.
+     *
+     * @param surface The surface
+     * @param model The model
+     */
+    public BrowserView(final LaunchkeyMiniMk3ControlSurface surface, final IModel model)
+    {
+        super ("Browser View", surface, model);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void drawGrid ()
+    {
+        final IPadGrid padGrid = this.surface.getPadGrid ();
+        for (int x = 0; x < 8; x++) {
+            padGrid.lightEx(x, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
+            padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
+        }
+
+        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void onGridNote (final int note, final int velocity)
+    {
+        if (note >= 36 && note <= 43)
+        {
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getButtonColor (final ButtonID buttonID)
+    {
+        if (buttonID == ButtonID.SCENE1) {
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI;
+        }
+
+        if (buttonID == ButtonID.SCENE2) {
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI;
+        }
+
+        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onButton (final ButtonID buttonID, final ButtonEvent event, final int velocity)
+    {
+        if (event == ButtonEvent.DOWN) {
+            final IBrowser browser = this.model.getBrowser ();
+
+            if (buttonID == ButtonID.SCENE1) {
+                this.surface.getViewManager ().setActive (Views.DRUM);
+                browser.stopBrowsing(true);
+            } else if (buttonID == ButtonID.SCENE2) {
+                this.surface.getViewManager ().setActive (Views.DRUM);
+                browser.stopBrowsing(false);
+            }
+        }
+    }
+}

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
@@ -48,8 +48,14 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
             padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
         }
 
-        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(0, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_HI);
+        padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
+        padGrid.lightEx(3, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
+        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
+        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
     }
 
 
@@ -81,16 +87,17 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
     @Override
     public void onButton (final ButtonID buttonID, final ButtonEvent event, final int velocity)
     {
-        if (event == ButtonEvent.DOWN) {
-            final IBrowser browser = this.model.getBrowser ();
+        if (!ButtonID.isSceneButton (buttonID) || event != ButtonEvent.DOWN)
+            return;
 
-            if (buttonID == ButtonID.SCENE1) {
-                this.surface.getViewManager ().setActive (Views.DRUM);
-                browser.stopBrowsing(true);
-            } else if (buttonID == ButtonID.SCENE2) {
-                this.surface.getViewManager ().setActive (Views.DRUM);
-                browser.stopBrowsing(false);
-            }
+        final IBrowser browser = this.model.getBrowser ();
+
+        if (buttonID == ButtonID.SCENE1) {
+            this.surface.getViewManager ().setActive (Views.DRUM);
+            browser.stopBrowsing(true);
+        } else if (buttonID == ButtonID.SCENE2) {
+            this.surface.getViewManager ().setActive (Views.DRUM);
+            browser.stopBrowsing(false);
         }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/BrowserView.java
@@ -57,14 +57,14 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
         padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
         padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
 
-        padGrid.lightEx(0, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(3, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(0, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(1, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+        padGrid.lightEx(2, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(3, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+        padGrid.lightEx(4, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(5, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+        padGrid.lightEx(6, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(7, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
     }
 
 
@@ -79,33 +79,18 @@ public class BrowserView extends AbstractView<LaunchkeyMiniMk3ControlSurface, La
         if (!browser.isActive ())
             return;
 
-        switch (note)
-        {
-            case 36:
-                browser.previousContentType();
-                break;
-            case 37:
-                browser.nextContentType();
-                break;
-            case 38:
+        switch (note) {
+            case 36 -> browser.previousContentType();
+            case 37 -> browser.nextContentType();
+            case 38 -> {
                 browser.selectPreviousFilterColumn();
                 browser.selectPreviousFilterColumn();
-                break;
-            case 39:
-                browser.selectNextFilterColumn();
-                break;
-            case 40:
-                browser.selectPreviousFilterItem(browser.getSelectedFilterColumn().getIndex());
-                break;
-            case 41:
-                browser.selectNextFilterItem(browser.getSelectedFilterColumn().getIndex());
-                break;
-            case 42:
-                browser.selectPreviousResult();
-                break;
-            case 43:
-                browser.selectNextResult();
-                break;
+            }
+            case 39 -> browser.selectNextFilterColumn();
+            case 40 -> browser.selectPreviousFilterItem(browser.getSelectedFilterColumn().getIndex());
+            case 41 -> browser.selectNextFilterItem(browser.getSelectedFilterColumn().getIndex());
+            case 42 -> browser.selectPreviousResult();
+            case 43 -> browser.selectNextResult();
         }
     }
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -115,6 +115,9 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public void onGridNote (final int note, final int velocity)
     {
+        if (velocity != 0)
+            return;
+
         if (note >= 44 && note <= 51)
         {
             // Top Row: note is 36 - 43

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -160,8 +160,13 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
 
         if (buttonID == ButtonID.SCENE1) {
             ICursorDevice cd = this.model.getCursorDevice();
-            this.surface.getViewManager ().setActive (Views.BROWSER);
-            this.model.getBrowser().replace(cd);
+            if (cd.doesExist()) {
+                this.surface.getViewManager ().setActive (Views.BROWSER);
+                this.model.getBrowser().replace(cd);
+            } else {
+                this.surface.getViewManager ().setActive (Views.BROWSER);
+                this.model.getBrowser ().insertAfterCursorDevice ();
+            }
         } else if (buttonID == ButtonID.SCENE2) {
             ICursorDevice cd = this.model.getCursorDevice();
             cd.toggleParameterPageSectionVisible();

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -39,6 +39,7 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     public void drawGrid ()
     {
         final IPadGrid padGrid = this.surface.getPadGrid ();
+
         padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
         padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_ORANGE);
         padGrid.lightEx(2, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
@@ -55,7 +56,8 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         ICursorDevice cd = this.model.getCursorDevice();
         final int deviceId = cd.getIndex();
 
-        for(int x = 0; x < deviceCount; x++)
+        // Draw White / Dim white circles for the Primary Device / Other Devices
+        for (int x = 0; x < deviceCount; x++)
         {
             if (deviceId == x)
             {
@@ -67,7 +69,8 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
             }
         }
 
-        for(int x = deviceCount; x < 8; x++)
+        // Dor the rest of the pads, turn them off
+        for (int x = deviceCount; x < 8; x++)
         {
             padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
         }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -142,7 +142,7 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         }
 
         if (buttonID == ButtonID.SCENE2) {
-            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE;
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI;
         }
 
         return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
@@ -155,6 +155,7 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         if (event == ButtonEvent.DOWN) {
             if (buttonID == ButtonID.SCENE1) {
                 ICursorDevice cd = this.model.getCursorDevice();
+                this.surface.getViewManager ().setActive (Views.BROWSER);
                 this.model.getBrowser().replace(cd);
             } else if (buttonID == ButtonID.SCENE2) {
                 ICursorDevice cd = this.model.getCursorDevice();

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -12,9 +12,13 @@ import de.mossgrabers.framework.controller.grid.IPadGrid;
 import de.mossgrabers.framework.daw.IModel;
 import de.mossgrabers.framework.daw.data.ICursorDevice;
 import de.mossgrabers.framework.daw.data.IParameter;
+import de.mossgrabers.framework.daw.data.IScene;
 import de.mossgrabers.framework.daw.data.bank.IDeviceBank;
 import de.mossgrabers.framework.daw.data.bank.IParameterPageBank;
+import de.mossgrabers.framework.daw.data.bank.ISceneBank;
 import de.mossgrabers.framework.featuregroup.AbstractView;
+import de.mossgrabers.framework.utils.ButtonEvent;
+import de.mossgrabers.framework.view.Views;
 
 
 /**
@@ -138,9 +142,24 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         }
 
         if (buttonID == ButtonID.SCENE2) {
-            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI;
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE;
         }
 
         return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onButton (final ButtonID buttonID, final ButtonEvent event, final int velocity)
+    {
+        if (event == ButtonEvent.DOWN) {
+            if (buttonID == ButtonID.SCENE1) {
+                ICursorDevice cd = this.model.getCursorDevice();
+                this.model.getBrowser().replace(cd);
+            } else if (buttonID == ButtonID.SCENE2) {
+                ICursorDevice cd = this.model.getCursorDevice();
+                cd.toggleParameterPageSectionVisible();
+            }
+        }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -11,6 +11,7 @@ import de.mossgrabers.framework.controller.ButtonID;
 import de.mossgrabers.framework.controller.grid.IPadGrid;
 import de.mossgrabers.framework.daw.IModel;
 import de.mossgrabers.framework.daw.data.ICursorDevice;
+import de.mossgrabers.framework.daw.data.IParameter;
 import de.mossgrabers.framework.daw.data.bank.IDeviceBank;
 import de.mossgrabers.framework.daw.data.bank.IParameterPageBank;
 import de.mossgrabers.framework.featuregroup.AbstractView;
@@ -128,11 +129,18 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         }
     }
 
-
     /** {@inheritDoc} */
     @Override
     public int getButtonColor (final ButtonID buttonID)
     {
-        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI;
+        if (buttonID == ButtonID.SCENE1) {
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI;
+        }
+
+        if (buttonID == ButtonID.SCENE2) {
+            return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI;
+        }
+
+        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
     }
 }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -120,15 +120,16 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
 
         if (note >= 44 && note <= 51)
         {
-            // Top Row: note is 36 - 43
+            // Top Row (Param Page): note is 36 - 43
             ICursorDevice cd = this.model.getCursorDevice();
             IParameterPageBank parameterPageBank = cd.getParameterPageBank();
             final int pageBankId = note - 44;
             parameterPageBank.scrollTo(pageBankId);
+            this.mvHelper.notifySelectedParameterPage ();
         }
         else if (note >= 36 && note <= 43)
         {
-            // Bottom Row: note is 36 - 43
+            // Bottom Row (Device): note is 36 - 43
             IDeviceBank mDeviceBank = this.model.getCursorDevice().getDeviceBank();
             int deviceId = note - 36;
             mDeviceBank.scrollTo(deviceId);

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -116,7 +116,7 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
             ICursorDevice cd = this.model.getCursorDevice();
             IParameterPageBank parameterPageBank = cd.getParameterPageBank();
             final int pageBankId = note - 44;
-            parameterPageBank.selectItemAtPosition(pageBankId);
+            parameterPageBank.scrollTo(pageBankId);
         }
         else if (note >= 36 && note <= 43)
         {
@@ -133,6 +133,6 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public int getButtonColor (final ButtonID buttonID)
     {
-        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
+        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI;
     }
 }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -78,6 +78,14 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public void onGridNote (final int note, final int velocity)
     {
+        // note is 36 - 43
+        if (note >= 36 && note <= 43)
+        {
+            IDeviceBank mDeviceBank = this.model.getCursorDevice().getDeviceBank();
+            int deviceId = note - 36;
+            mDeviceBank.scrollTo(deviceId);
+            mDeviceBank.selectItemAtPosition(deviceId);
+        }
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -152,15 +152,16 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public void onButton (final ButtonID buttonID, final ButtonEvent event, final int velocity)
     {
-        if (event == ButtonEvent.DOWN) {
-            if (buttonID == ButtonID.SCENE1) {
-                ICursorDevice cd = this.model.getCursorDevice();
-                this.surface.getViewManager ().setActive (Views.BROWSER);
-                this.model.getBrowser().replace(cd);
-            } else if (buttonID == ButtonID.SCENE2) {
-                ICursorDevice cd = this.model.getCursorDevice();
-                cd.toggleParameterPageSectionVisible();
-            }
+        if (!ButtonID.isSceneButton (buttonID) || event != ButtonEvent.DOWN)
+            return;
+
+        if (buttonID == ButtonID.SCENE1) {
+            ICursorDevice cd = this.model.getCursorDevice();
+            this.surface.getViewManager ().setActive (Views.BROWSER);
+            this.model.getBrowser().replace(cd);
+        } else if (buttonID == ButtonID.SCENE2) {
+            ICursorDevice cd = this.model.getCursorDevice();
+            cd.toggleParameterPageSectionVisible();
         }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -1,0 +1,90 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2017-2021
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.controller.novation.launchkey.mini.view;
+
+import de.mossgrabers.controller.novation.launchkey.mini.LaunchkeyMiniMk3Configuration;
+import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ColorManager;
+import de.mossgrabers.controller.novation.launchkey.mini.controller.LaunchkeyMiniMk3ControlSurface;
+import de.mossgrabers.framework.controller.ButtonID;
+import de.mossgrabers.framework.controller.grid.IPadGrid;
+import de.mossgrabers.framework.daw.IModel;
+import de.mossgrabers.framework.daw.data.ICursorDevice;
+import de.mossgrabers.framework.daw.data.bank.IDeviceBank;
+import de.mossgrabers.framework.featuregroup.AbstractView;
+
+
+/**
+ * The pad mode user view.
+ *
+ * @author J&uuml;rgen Mo&szlig;graber
+ */
+public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, LaunchkeyMiniMk3Configuration>
+{
+    /**
+     * Constructor.
+     *
+     * @param surface The surface
+     * @param model The model
+     */
+    public DeviceView(final LaunchkeyMiniMk3ControlSurface surface, final IModel model)
+    {
+        super ("Device View", surface, model);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void drawGrid ()
+    {
+        final IPadGrid padGrid = this.surface.getPadGrid ();
+        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
+        padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_ORANGE);
+        padGrid.lightEx(2, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
+        padGrid.lightEx(3, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
+        padGrid.lightEx(4, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
+        padGrid.lightEx(5, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
+        padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
+        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
+
+
+        IDeviceBank mDeviceBank = this.model.getCursorDevice().getDeviceBank();
+        final int deviceCount = mDeviceBank.getItemCount();
+
+        ICursorDevice cd = this.model.getCursorDevice();
+        final int deviceId = cd.getIndex();
+
+        for(int x = 0; x < deviceCount; x++)
+        {
+            if (deviceId == x)
+            {
+                padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_WHITE);
+            }
+            else
+            {
+                padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREY_LO);
+            }
+        }
+
+        for(int x = deviceCount; x < 8; x++)
+        {
+            padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);
+        }
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void onGridNote (final int note, final int velocity)
+    {
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public int getButtonColor (final ButtonID buttonID)
+    {
+        return LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK;
+    }
+}

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -12,6 +12,7 @@ import de.mossgrabers.framework.controller.grid.IPadGrid;
 import de.mossgrabers.framework.daw.IModel;
 import de.mossgrabers.framework.daw.data.ICursorDevice;
 import de.mossgrabers.framework.daw.data.bank.IDeviceBank;
+import de.mossgrabers.framework.daw.data.bank.IParameterPageBank;
 import de.mossgrabers.framework.featuregroup.AbstractView;
 
 
@@ -38,17 +39,29 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public void drawGrid ()
     {
+        final int[] brightColors = {
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI
+        };
+
+        final int[] dimColors = {
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_AMBER_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_LO,
+            LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_LO
+        };
+
         final IPadGrid padGrid = this.surface.getPadGrid ();
-
-        padGrid.lightEx(0, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_RED_HI);
-        padGrid.lightEx(1, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_ORANGE);
-        padGrid.lightEx(2, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_YELLOW_HI);
-        padGrid.lightEx(3, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_GREEN_HI);
-        padGrid.lightEx(4, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_LIME_HI);
-        padGrid.lightEx(5, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLUE_HI);
-        padGrid.lightEx(6, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_MAGENTA_HI);
-        padGrid.lightEx(7, 0, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_PINK_HI);
-
 
         IDeviceBank mDeviceBank = this.model.getCursorDevice().getDeviceBank();
         final int deviceCount = mDeviceBank.getItemCount();
@@ -56,7 +69,23 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
         ICursorDevice cd = this.model.getCursorDevice();
         final int deviceId = cd.getIndex();
 
-        // Draw White / Dim white circles for the Primary Device / Other Devices
+        IParameterPageBank parameterPageBank = cd.getParameterPageBank();
+        final int parameterPageId = parameterPageBank.getSelectedItemIndex();
+
+        // Draw Rainbow pads on the top row for selecting the parameter page
+        for (int x = 0; x < 8; x++)
+        {
+            if (parameterPageId == x)
+            {
+                padGrid.lightEx(x, 0, brightColors[x]);
+            }
+            else
+            {
+                padGrid.lightEx(x, 0, dimColors[x]);
+            }
+        }
+
+        // Draw White / Dim white pads for the Primary Device / Other Devices on the bottom row
         for (int x = 0; x < deviceCount; x++)
         {
             if (deviceId == x)
@@ -69,7 +98,7 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
             }
         }
 
-        // Dor the rest of the pads, turn them off
+        // For the rest of the bottom row pads, turn them off
         for (int x = deviceCount; x < 8; x++)
         {
             padGrid.lightEx(x, 1, LaunchkeyMiniMk3ColorManager.LAUNCHKEY_COLOR_BLACK);

--- a/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchkey/mini/view/DeviceView.java
@@ -110,9 +110,17 @@ public class DeviceView extends AbstractView<LaunchkeyMiniMk3ControlSurface, Lau
     @Override
     public void onGridNote (final int note, final int velocity)
     {
-        // note is 36 - 43
-        if (note >= 36 && note <= 43)
+        if (note >= 44 && note <= 51)
         {
+            // Top Row: note is 36 - 43
+            ICursorDevice cd = this.model.getCursorDevice();
+            IParameterPageBank parameterPageBank = cd.getParameterPageBank();
+            final int pageBankId = note - 44;
+            parameterPageBank.selectItemAtPosition(pageBankId);
+        }
+        else if (note >= 36 && note <= 43)
+        {
+            // Bottom Row: note is 36 - 43
             IDeviceBank mDeviceBank = this.model.getCursorDevice().getDeviceBank();
             int deviceId = note - 36;
             mDeviceBank.scrollTo(deviceId);


### PR DESCRIPTION
Hi Moss,
Thanks for writing such an awesome controller framework. I've spent more than a few nights making changes and I was hoping for some input / help with this PR (which is not ready to be merged). So I've created a device view and browser view for the Launchkey Mini MK3. The device view shows devices on the bottom row and parameter pages on the top row (color coded) and supports up to 8 of each (this is how the MK2 version handles it and it's quite nice). The main problem I have is that I had to replace the drum view to get it to engage. I would ideally like to have it replace the current device mode with the device view (and an orange button) which will also trigger the device knob mode when activated. If that's not possible or desirable, a different pad to trigger it would be fine also. I've tried a bunch of different button and output IDs when registering my view, but haven't gotten it to work. Any ideas how this might work? 

The other thing I would like to do is a knob mode for the browser like the Beatstep has, where if you hold down some shift button, the knobs will control the filters (this is really nice on the Beatstep since it has 16 knobs and no shift is needed) and without it, it will control the remote control params as usual. This I have not been able to figure out if it's even possible as I haven't figured out how to get it to trigger my custom knob mode at all. It's less important though as I added a 'keypad' and next/previous tab and selection buttons similar to what you did with the big Launchkey MK3, but if you have any ideas or tips, they'd be much appreciated.

Also, would you be interested in this PR if it could be made to work without disturbing any of the functionality you've worked on? 

I also have a bunch of tweaks and changes for the Beatstep, some of which are a bit more messy, but definitely extractable. If you are interested in any of the features (more device functionality, controlling 16 mixer channels at once, triggering save, etc.), I could pull them out into a PR for that: https://github.com/lucian303/DrivenByMoss/tree/beatstep-enhanced 