### PR TITLE
fix: updates Ableton Push 2 midiDiscoveryPair on Linux

### DIFF
--- a/src/main/java/de/mossgrabers/controller/ableton/push/PushControllerDefinition.java
+++ b/src/main/java/de/mossgrabers/controller/ableton/push/PushControllerDefinition.java
@@ -62,9 +62,6 @@ public class PushControllerDefinition extends DefaultControllerDefinition
                 break;
 
             case LINUX:
-                midiDiscoveryPairs.add (this.addDeviceDiscoveryPair (this.isMkII ? "Ableton Push 2 MIDI 1" : "Ableton Push MIDI 2"));
-                break;
-
             case MAC:
                 midiDiscoveryPairs.add (this.addDeviceDiscoveryPair (this.isMkII ? "Ableton Push 2 Live Port" : "Ableton Push User Port"));
                 break;


### PR DESCRIPTION
In Linux kernel commit eb596e0fd13c83b4a66559a45b57b71aac340d30, midi device naming was changed. This patch allows the Push 2 to be auto detected appropriately. See [mailing list patch](https://lore.kernel.org/all/20210226212617.24616-1-george@george-graphics.co.uk/) for more details.