### PR TITLE
feature(push+push2): add ability to toggle selection preview in browser

### DIFF
--- a/src/main/java/de/mossgrabers/bitwig/framework/daw/BrowserImpl.java
+++ b/src/main/java/de/mossgrabers/bitwig/framework/daw/BrowserImpl.java
@@ -67,6 +67,8 @@ public class BrowserImpl extends AbstractBrowser
         this.browser.selectedContentTypeIndex ().markInterested ();
         this.browser.selectedContentTypeName ().markInterested ();
         this.browser.contentTypeNames ().markInterested ();
+        this.browser.shouldAudition ().markInterested ();
+        this.browser.canAudition ().markInterested ();
 
         this.filterColumns = new BrowserFilterColumn []
         {
@@ -252,6 +254,23 @@ public class BrowserImpl extends AbstractBrowser
     public void selectNextResult ()
     {
         this.cursorResult.selectNext ();
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isPreviewEnabled()
+    {
+        return this.browser.shouldAudition().get();
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void setPreviewEnabled(boolean value)
+    {
+        if(this.browser.canAudition().get())
+            this.browser.shouldAudition().set(value);
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/ableton/push/mode/device/DeviceBrowserMode.java
+++ b/src/main/java/de/mossgrabers/controller/ableton/push/mode/device/DeviceBrowserMode.java
@@ -149,7 +149,12 @@ public class DeviceBrowserMode extends BaseMode<IItem>
         if (event != ButtonEvent.DOWN)
             return;
         if (this.isPush2)
-            this.selectNext (index, 1);
+        {
+            if (this.surface.isShiftPressed () && index == 7)
+                togglePreviewMode();
+            else
+                this.selectNext (index, 1);
+        }
         else
             this.selectPrevious (index, 1);
     }
@@ -164,7 +169,12 @@ public class DeviceBrowserMode extends BaseMode<IItem>
         if (this.isPush2)
             this.selectPrevious (index, 1);
         else
-            this.selectNext (index, 1);
+        {
+            if (this.surface.isShiftPressed () && index == 6)
+                togglePreviewMode();
+            else
+                this.selectNext (index, 1);
+        }
     }
 
 
@@ -190,6 +200,9 @@ public class DeviceBrowserMode extends BaseMode<IItem>
                 final String info1 = infoText.length () > 17 ? infoText.substring (0, 17) : infoText;
                 final String info2 = infoText.length () > 17 ? infoText.substring (17, infoText.length ()) : "";
                 display.setCell (0, 7, selectedContentType).setBlock (3, 0, info1).setBlock (3, 1, info2);
+
+                final String previewIndication = "Preview: " + (browser.isPreviewEnabled() ? "On" : "Off");
+                display.setCell (3, 7, previewIndication);
 
                 final String sel1 = selectedResult.length () > 17 ? selectedResult.substring (0, 17) : selectedResult;
                 final String sel2 = selectedResult.length () > 17 ? selectedResult.substring (17, selectedResult.length ()) : "";
@@ -265,7 +278,9 @@ public class DeviceBrowserMode extends BaseMode<IItem>
                     final String menuBottomName = getColumnName (column);
                     display.addOptionElement (headerTopName, column.isEmpty () ? "" : column.get ().getName (), i == this.filterColumn, headerBottomName, menuBottomName, !menuBottomName.equals (" "), false);
                 }
-                display.addOptionElement ("", browser.getSelectedContentType (), this.filterColumn == -1, "", "", false, false);
+
+                final String previewIndication = "Preview: " + (browser.isPreviewEnabled() ? "On" : "Off");
+                display.addOptionElement ("", browser.getSelectedContentType (), this.filterColumn == -1, "", previewIndication, browser.isPreviewEnabled(), false);
                 break;
 
             case DeviceBrowserMode.SELECTION_PRESET:
@@ -482,5 +497,12 @@ public class DeviceBrowserMode extends BaseMode<IItem>
             return "";
         final IBrowserColumn browserColumn = column.get ();
         return browserColumn.getCursorName ().equals (browserColumn.getWildcard ()) ? " " : browserColumn.getCursorName (12);
+    }
+
+    private void togglePreviewMode ()
+    {
+        final IBrowser browser = this.model.getBrowser ();
+        if (browser.isActive ())
+            browser.setPreviewEnabled(!browser.isPreviewEnabled());
     }
 }

--- a/src/main/java/de/mossgrabers/framework/daw/IBrowser.java
+++ b/src/main/java/de/mossgrabers/framework/daw/IBrowser.java
@@ -276,4 +276,18 @@ public interface IBrowser extends IObserverManagement
      * @return The info text
      */
     String getInfoText ();
+
+    /**
+     * Tells whether preview is enabled
+     *
+     * @return True is preview is enabled
+     */
+    boolean isPreviewEnabled();
+
+    /**
+     * Activate or deactivate preview
+     *
+     * @param value Should preview for the selected item be enabled or not
+     */
+    void setPreviewEnabled(boolean value);
 }


### PR DESCRIPTION
This PR adds the ability to toggle the state of "Enable preview of selected item" in the browser for Push and Push2.

To toggle preview mode: Shift+8th button on the bottom row.
An indication on the state of preview mode is displayed on the bottom right corner of the push display.

Would you would be interested in integrating this feature ?
I would totally understand if the UI does not make sense to you (button combination to toggle and position of the indication on the screen). I can edit it to fit your flow.
I can then submit a PR on the documentation repository to add this feature.

Disclamer: I added this feature for Push1 and Push2, but I do not own a Push1, so I was not able to test. **DO NOT MERGE BEFORE TESTING ON PUSH1.**