### PR TITLE
Added parameter type detection to Virtual Fader Implementation

### DIFF
--- a/src/main/java/de/mossgrabers/controller/novation/launchpad/view/DeviceView.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchpad/view/DeviceView.java
@@ -42,6 +42,7 @@ public class DeviceView extends AbstractFaderView
     public void setupFader (final int index)
     {
         this.surface.setupFader (index, LaunchpadColorManager.DAW_INDICATOR_COLORS.get (index).intValue (), false);
+        this.onValueKnob( index, this.getFaderValue(index) );  //FIX -- issue with catch mode by initializing fader value at setup
     }
 
 
@@ -49,7 +50,8 @@ public class DeviceView extends AbstractFaderView
     @Override
     public void onValueKnob (final int index, final int value)
     {
-        this.cursorDevice.getParameterBank ().getItem (index).setValue (value);
+        this.cursorDevice.getParameterBank ().getItem (index).setValueImmediatly( value ); //FIX -- issue with relative scaling mode by always forcing actual value
+        this.cursorDevice.getParameterBank ().getItem (index).setValue( value );
     }
 
 

--- a/src/main/java/de/mossgrabers/framework/controller/grid/VirtualFaderImpl.java
+++ b/src/main/java/de/mossgrabers/framework/controller/grid/VirtualFaderImpl.java
@@ -52,6 +52,8 @@ public class VirtualFaderImpl implements IVirtualFader
     private int                         moveTimerDelay;
     private int                         moveDestination;
 
+    private int                         moveTargetValue;
+    private boolean                     isKnobType;
 
     /**
      * Constructor. Does not update a slider on the grid. Use getColorState method to draw the fader
@@ -125,6 +127,12 @@ public class VirtualFaderImpl implements IVirtualFader
         this.moveDelay = SPEED_SCALE[velocity];
         this.moveTimerDelay = SPEED_SCALE[SPEED_SCALE.length - 1 - velocity];
 
+        // compensate for parameter type detection delay
+        this.moveTimerDelay -= 1;
+
+        // reset paramter type detection flag
+        this.isKnobType = false;
+        
         final int min = row * PAD_VALUE_AMOUNT;
         final int max = Math.min (127, (row + 1) * PAD_VALUE_AMOUNT - 1);
         int newDestination = this.smoothFaderValue (row, max);
@@ -152,14 +160,35 @@ public class VirtualFaderImpl implements IVirtualFader
     {
         final int current = this.callback.getValue ();
         if (current < this.moveDestination)
-            this.callback.setValue (Math.min (current + this.moveDelay, this.moveDestination));
+            this.moveTargetValue = Math.min (current + this.moveDelay, this.moveDestination);
         else if (current > this.moveDestination)
-            this.callback.setValue (Math.max (current - this.moveDelay, this.moveDestination));
+            this.moveTargetValue = Math.max (current - this.moveDelay, this.moveDestination);
         else
             return;
 
-        this.host.scheduleTask (this::moveFaderToDestination, this.moveTimerDelay);
+        this.callback.setValue ( this.moveTargetValue );
+
+        // YIELD to Bitwig to allow the parameter value to update properly
+        this.host.scheduleTask(this::moveFaderToDestinationCallback, 1);
     }
+
+    protected void moveFaderToDestinationCallback ()
+    {
+        final int updatedValue = this.callback.getValue();
+
+        // Compare updated parameter value to target update value, if different it means that the parameter is
+        // either a boolean or selection list type and the destination value should be force set
+        if( !this.isKnobType && updatedValue != this.moveTargetValue ) 
+        {
+            this.callback.setValue( this.moveDestination );
+        } 
+        else 
+        {
+            this.isKnobType = true;
+            this.host.scheduleTask(this::moveFaderToDestination, this.moveTimerDelay);
+        }
+    }
+
 
 
     /**


### PR DESCRIPTION
**Description:**
This pull request adds parameter type detection to the controller framework virtual fader implementation.

**Reason for Patch:**
The current implementation doesn't properly handle boolean and selection type parameters in the device interface as tested with Launchpad X and Launchpad Mini mk3.

**Methodology:**
This patch introduces an intermediary callback function that compares the actual current value of the parameter vs the requested value to determine whether or not the parameter is a knob. If the parameter is not a knob then the value is set immediately bypassing the smooth step algorithm. 

The callback is necessary to allow a yield frame to Bitwig so that the requested parameter value is actually updated, this delay isn't noticeable when using the device and is accounted for by decrementing the smooth step timer by 1.

**Demonstration:**
[Launchpad X running  unpatched 15.3 release](https://www.youtube.com/watch?v=TriPjFE0bnI)
[Launchpad X with patch](https://www.youtube.com/watch?v=fbMXszElK0c)
_Please read the full video description for additional details_

**Additional Patch for Launchpad Controllers:**
Additionally there is a two line patch to the Launchpad DeviceView that fixes issues with takeover modes other than immediate.
To fix the issue with catch mode the fader is initialized with the current parameter value.
To fix the issue with relative mode the knob value is set immediately on change.

The reasoning behind this is -- the controller device should always accurately represent the internal state of the application and controller inputs should always produce the "least surprising response" from the application

