### PR TITLE
Added option to enable/disable automatic switching to the browser interface for launchpad controllers

### DIFF
--- a/src/main/java/de/mossgrabers/controller/novation/launchpad/LaunchpadConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchpad/LaunchpadConfiguration.java
@@ -90,6 +90,7 @@ public class LaunchpadConfiguration extends AbstractConfiguration
         this.activateExcludeDeactivatedItemsSetting (globalSettings);
         this.activateIncludeMasterSetting (globalSettings);
         this.activateNewClipLengthSetting (globalSettings);
+        this.activateAutoBrowserInterface (globalSettings);
 
         ///////////////////////////
         // Pad Sensitivity

--- a/src/main/java/de/mossgrabers/controller/novation/launchpad/command/trigger/SelectDeviceViewCommand.java
+++ b/src/main/java/de/mossgrabers/controller/novation/launchpad/command/trigger/SelectDeviceViewCommand.java
@@ -53,7 +53,7 @@ public class SelectDeviceViewCommand extends AbstractTriggerCommand<LaunchpadCon
         }
 
         final IBrowser browser = this.model.getBrowser ();
-        if (viewManager.isActive (Views.BROWSER))
+        if (viewManager.isActive (Views.BROWSER) || browser.isActive () )
         {
             browser.stopBrowsing (false);
             viewManager.setActive (Views.DEVICE);

--- a/src/main/java/de/mossgrabers/framework/configuration/AbstractConfiguration.java
+++ b/src/main/java/de/mossgrabers/framework/configuration/AbstractConfiguration.java
@@ -125,6 +125,9 @@ public abstract class AbstractConfiguration implements Configuration
     /** Setting for the footswitch functionality. */
     public static final Integer      FOOTSWITCH_4                      = Integer.valueOf (41);
 
+    /** Setting for auto-browser interface setting. */
+    public static final Integer      ACTIVATE_AUTO_BROWSER_VIEW        = Integer.valueOf (42);
+
     // Implementation IDs start at 50
 
     protected static final String    CATEGORY_DRUMS                    = "Drum Sequencer";
@@ -351,6 +354,7 @@ public abstract class AbstractConfiguration implements Configuration
     private IEnumSetting                              noteRepeatModeSetting;
     private IEnumSetting                              noteRepeatOctaveSetting;
     private IEnumSetting                              midiEditChannelSetting;
+    private IEnumSetting                              browserAutoViewSetting;
     private final List<IEnumSetting>                  instrumentSettings          = new ArrayList<> (7);
     private final List<IEnumSetting>                  audioSettings               = new ArrayList<> (3);
     private final List<IEnumSetting>                  effectSettings              = new ArrayList<> (3);
@@ -414,10 +418,11 @@ public abstract class AbstractConfiguration implements Configuration
 
     private boolean                                   isDeleteActive              = false;
     private boolean                                   isDuplicateActive           = false;
-
+    
     private RecordFunction                            recordButtonFunction        = RecordFunction.RECORD_ARRANGER;
     private RecordFunction                            shiftedRecordButtonFunction = RecordFunction.NEW_CLIP;
 
+    private boolean                                   browserAutoView               = true;
 
     /**
      * Constructor.
@@ -1334,6 +1339,31 @@ public abstract class AbstractConfiguration implements Configuration
     }
 
 
+    /**
+     * Activate the auto-browser interface state change.
+     *
+     * @param settingsUI The settings
+     */
+    protected void activateAutoBrowserInterface (final ISettingsUI settingsUI)
+    {
+        this.browserAutoViewSetting = settingsUI.getEnumSetting ("Enable Auto-Browser View", CATEGORY_WORKFLOW, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
+        this.browserAutoViewSetting.addValueObserver (value -> {
+            this.browserAutoView = "On".equals (value);
+            this.notifyObservers (ACTIVATE_AUTO_BROWSER_VIEW);
+        });
+
+        this.isSettingActive.add (ACTIVATE_AUTO_BROWSER_VIEW);
+    }    
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isAutoBrowserViewActive ()
+    {
+        return this.browserAutoView;
+    }
+    
+    
+    
     /**
      * Activate the knob speed settings.
      *

--- a/src/main/java/de/mossgrabers/framework/configuration/Configuration.java
+++ b/src/main/java/de/mossgrabers/framework/configuration/Configuration.java
@@ -497,4 +497,11 @@ public interface Configuration
      * @return The function index
      */
     RecordFunction getShiftedRecordButtonFunction ();
+
+    /**
+     * Get the auto browser view setting.
+     *
+     * @return True if auto browser view is enabled
+     */
+    boolean isAutoBrowserViewActive ();
 }

--- a/src/main/java/de/mossgrabers/framework/controller/AbstractControllerSetup.java
+++ b/src/main/java/de/mossgrabers/framework/controller/AbstractControllerSetup.java
@@ -282,9 +282,10 @@ public abstract class AbstractControllerSetup<S extends IControlSurface<C>, C ex
             if (isActive.booleanValue ())
             {
                 final Views previousViewId = viewManager.getPreviousID ();
-                viewManager.setTemporary (browserView);
                 if (viewManager.getPreviousID () == Views.SHIFT)
                     viewManager.setPreviousID (previousViewId);
+                    if ( this.configuration.isAutoBrowserViewActive () )
+                        viewManager.setTemporary (browserView);
             }
             else if (viewManager.isActive (browserView))
                 viewManager.restore ();


### PR DESCRIPTION
This pull request adds a configuration option that allows the user to disable automatic switching to the browser interface on launchpad controllers.

**Reasoning:**
The automatic switching to the browser interface restricts the user choice in creative workflow [0]
This mode switch is also the only bitwig to controller initiated state change and therefore violates the UI principle of "least surprise" 

**Backwards Compatibility:**
The option is implemented as ON by default to preserve the behavior in previous releases.
Manually opening/closing the browser from the launchpad still works normally

**Personal Note:**
[0] I prefer being able to fully audition instruments using the launchpad while navigating the browser with keyboard/mouse 