### PR TITLE
Fix: 3rd shift on chromatic mode

### DIFF
--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -36,8 +36,9 @@ class ScaleGrid
      * @param rows The number of rows of the grid
      * @param cols The number of columns of the grid
      * @param shift The number of scale steps that the notes in the next rows are shifted (e.g. 4)
+     * @param semitoneShift The number of semitones the notes in the next rows are shifted in chromatic mode
      */
-    public ScaleGrid (final Scale scale, final ScaleLayout layout, final Orientation orientation, final int rows, final int cols, final int shift)
+    public ScaleGrid (final Scale scale, final ScaleLayout layout, final Orientation orientation, final int rows, final int cols, final int shift, final int semitoneShift)
     {
         final int size = cols * rows;
         this.matrix = new int [size];
@@ -48,11 +49,6 @@ class ScaleGrid
         final int len = intervals.length;
 
         final boolean isUp = orientation == Orientation.ORIENT_UP;
-        final int shiftedNote;
-        if (shift == rows)
-            shiftedNote = rows;
-        else
-            shiftedNote = shift == 7 ? 12 : cols - shift;
         final int centerOffset = layout == ScaleLayout.EIGHT_UP_CENTER || layout == ScaleLayout.EIGHT_RIGHT_CENTER ? -3 : 0;
 
         for (int row = 0; row < rows; row++)
@@ -79,7 +75,7 @@ class ScaleGrid
 
                 final int index = row * cols + column;
                 this.matrix[index] = oct * 12 + intervals[offset % len];
-                this.chromatic[index] = y * shiftedNote + x;
+                this.chromatic[index] = y * semitoneShift + x;
             }
         }
     }

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -99,7 +99,8 @@ public class Scales
     private ScaleLayout                 scaleLayout              = ScaleLayout.FOURTH_UP;
     private Orientation                 orientation              = Orientation.ORIENT_UP;
     private boolean                     chromaticOn              = false;
-    private int                         shift                    = 3;
+    private int                         scaleShift               = 3;
+    private int                         semitoneShift            = 5;
     private int                         octave                   = 0;
     private int                         drumOffset;
     private int                         drumDefaultOffset;
@@ -329,23 +330,23 @@ public class Scales
         {
             case FOURTH_UP:
             case FOURTH_RIGHT:
-                this.setPlayShift (3);
+                this.setPlayShift (3, 5);
                 break;
             case THIRD_UP:
             case THIRD_RIGHT:
-                this.setPlayShift (2);
+                this.setPlayShift (2, 4);
                 break;
             case SEQUENT_UP:
-                this.setPlayShift (this.numRows);
+                this.setPlayShift (this.numRows, this.numRows);
                 break;
             case SEQUENT_RIGHT:
-                this.setPlayShift (this.numColumns);
+                this.setPlayShift (this.numColumns, this.numColumns);
                 break;
             case EIGHT_UP:
             case EIGHT_RIGHT:
             case EIGHT_UP_CENTER:
             case EIGHT_RIGHT_CENTER:
-                this.setPlayShift (7);
+                this.setPlayShift (7, 12);
                 break;
         }
     }
@@ -622,13 +623,15 @@ public class Scales
 
 
     /**
-     * Sets the number of scale steps that the notes in the next rows are shifted (e.g. 4).
+     * Sets the number of scale and semitone steps that the notes in the next rows are shifted (e.g. 4).
      *
-     * @param shift The steps
+     * @param scaleShift The steps
+     * @param semitoneShift The steps
      */
-    public void setPlayShift (final int shift)
+    public void setPlayShift (final int scaleShift, final int semitoneShift)
     {
-        this.shift = shift;
+        this.scaleShift = scaleShift;
+        this.semitoneShift = semitoneShift;
         this.generateMatrices ();
     }
 
@@ -638,9 +641,19 @@ public class Scales
      *
      * @return The steps
      */
-    public int getPlayShift ()
+    public int getScaleShift ()
     {
-        return this.shift;
+        return this.scaleShift;
+    }
+
+    /**
+     * Get the number of semitones the notes in the next rows are shifted in chromatic mode
+     *
+     * @return The number of semitone
+     */
+    public int getSemitoneShift ()
+    {
+        return this.semitoneShift;
     }
 
 
@@ -1070,7 +1083,7 @@ public class Scales
         this.chordGrids.clear ();
         for (final Scale scale: Scale.values ())
         {
-            this.scaleGrids.put (scale, new ScaleGrid (scale, this.scaleLayout, this.orientation, this.numRows, this.numColumns, this.shift));
+            this.scaleGrids.put (scale, new ScaleGrid (scale, this.scaleLayout, this.orientation, this.numRows, this.numColumns, this.scaleShift, this.semitoneShift));
             this.chordGrids.put (scale, new ChordGrid (scale, this.numRows, this.numColumns));
         }
     }


### PR DESCRIPTION
Hi Moss, 

I found that when shifting by 3rd in chromatic mode on a Launchpad, it actually shifts by 6 semitones. And since the issue is dependent on the grid size, it could give different results on other hardware.

So I made a little fix for that by expliciting the number of semitones for each scale layout.