### PR TITLE
Staggered scale layout

### DIFF
--- a/src/main/java/de/mossgrabers/framework/configuration/AbstractConfiguration.java
+++ b/src/main/java/de/mossgrabers/framework/configuration/AbstractConfiguration.java
@@ -901,7 +901,7 @@ public abstract class AbstractConfiguration implements Configuration
     protected void activateScaleSetting (final ISettingsUI settingsUI)
     {
         final String [] scaleNames = Scale.getNames ();
-        this.scaleSetting = settingsUI.getEnumSetting ("Scale", CATEGORY_SCALES, scaleNames, scaleNames[0]);
+        this.scaleSetting = settingsUI.getEnumSetting ("Scale", CATEGORY_SCALES, scaleNames, Scale.MAJOR.getName());
         this.scaleSetting.addValueObserver (value -> {
             this.scale = value;
             this.notifyObservers (SCALES_SCALE);

--- a/src/main/java/de/mossgrabers/framework/scale/Scale.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scale.java
@@ -130,7 +130,7 @@ public enum Scale
     /** The Messiaen 7 scale. */
     MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 }),
 
-    /** The 12-tone Chromatic scale; can be usefully mapped by scale mode. Stagger layout makes this highly playable. */
+    /** The 12-tone Chromatic scale; can be usefully mapped by scale mode. Staggered layout makes this very playable. */
     CHROMATIC("Chromatic", new int[]                   { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
 
     // @formatter:on

--- a/src/main/java/de/mossgrabers/framework/scale/Scale.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scale.java
@@ -130,7 +130,7 @@ public enum Scale
     /** The Messiaen 7 scale. */
     MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 }),
 
-    /** The 12-tone Chromatic scale. */
+    /** The 12-tone Chromatic scale; can be usefully mapped by scale mode. Stagger layout makes this highly playable. */
     CHROMATIC("Chromatic", new int[]                   { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
 
     // @formatter:on

--- a/src/main/java/de/mossgrabers/framework/scale/Scale.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scale.java
@@ -128,7 +128,10 @@ public enum Scale
     MESSIAEN_6("Messiaen 6", new int []                { 0, 2, 4, 5, 6, 8, 10, 11 }),
 
     /** The Messiaen 7 scale. */
-    MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 });
+    MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 }),
+
+    /** The 12-tone Chromatic scale. */
+    CHROMATIC("Chromatic", new int[]                   { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
 
     // @formatter:on
 

--- a/src/main/java/de/mossgrabers/framework/scale/Scale.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scale.java
@@ -19,6 +19,9 @@ public enum Scale
 {
     // @formatter:off
 
+    /** The 12-tone Chromatic scale; this is usefully mapped by scale mode. */
+    CHROMATIC("Chromatic", new int[]                   { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }),
+
     /** The Major scale. */
     MAJOR("Major", new int []                          { 0, 2, 4, 5, 7, 9, 11 }),
 
@@ -128,10 +131,7 @@ public enum Scale
     MESSIAEN_6("Messiaen 6", new int []                { 0, 2, 4, 5, 6, 8, 10, 11 }),
 
     /** The Messiaen 7 scale. */
-    MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 }),
-
-    /** The 12-tone Chromatic scale; can be usefully mapped by scale mode. Staggered layout makes this very playable. */
-    CHROMATIC("Chromatic", new int[]                   { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
+    MESSIAEN_7("Messiaen 7", new int []                { 0, 1, 2, 3, 5, 6, 7, 8, 9, 11 });
 
     // @formatter:on
 

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -58,24 +58,27 @@ class ScaleGrid
             {
                 final int y = isUp ? row : column;
                 final int x = isUp ? column : row;
-
-                int s = shift;
-                // Fix 8th layout for scales which do not have 7 steps
-                if (shift == 7)
-                    s = len;
-                int offset = y * s + x + centerOffset;
-
-                int oct = offset / len;
-
-                // Fix negative values introduced by centerOffset
-                if (offset < 0)
-                {
-                    offset = len + offset;
-                    oct = offset / len - 1;
-                }
-
                 final int index = row * cols + column;
-                this.matrix[index] = oct * 12 + intervals[offset % len];
+
+                if (layout == ScaleLayout.ISOMORPHIC_UP || layout == ScaleLayout.ISOMORPHIC_RIGHT) {
+                    this.matrix[index] = x * shift + y * semitoneShift - 4;
+                } else {
+                    int s = shift;
+                    // Fix 8th layout for scales which do not have 7 steps
+                    if (shift == 7)
+                        s = len;
+                    int offset = y * s + x + centerOffset;
+
+                    int oct = offset / len;
+
+                    // Fix negative values introduced by centerOffset
+                    if (offset < 0) {
+                        offset = len + offset;
+                        oct = offset / len - 1;
+                    }
+
+                    this.matrix[index] = oct * 12 + intervals[offset % len];
+                }
                 this.chromatic[index] = y * semitoneShift + x;
             }
         }

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -61,7 +61,15 @@ class ScaleGrid
                 final int index = row * cols + column;
 
                 if (layout == ScaleLayout.ISOMORPHIC_UP || layout == ScaleLayout.ISOMORPHIC_RIGHT) {
-                    this.matrix[index] = x * shift + y * semitoneShift - 4;
+                    // We could repurpose the shift parameters as fixed semitone deltas dx, dy:
+                    // this.matrix[index] = x * shift + y * semitoneShift - 4;
+                    // But that is not very flexible without dedicated configuration for dx, dy.
+                    // Provide at least some alternatives for now by using the selected scale's first and median steps
+                    // as deltas.
+                    this.matrix[index] = x * intervals[1] + y * intervals[intervals.length / 2] - 4;
+                } else if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
+                    final int step = x * 2 + y * shift;
+                    this.matrix[index] = 12 * (step / len) + intervals[step % len];
                 } else {
                     int s = shift;
                     // Fix 8th layout for scales which do not have 7 steps

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -60,9 +60,10 @@ class ScaleGrid
                 final int x = isUp ? column : row;
                 final int index = row * cols + column;
 
-                if (layout == ScaleLayout.FOLDED_UP || layout == ScaleLayout.FOLDED_RIGHT) {
-                    final int step = x + y * shift;
-                    this.matrix[index] = 12 * (step / len) + intervals[step % len];
+                if (layout == ScaleLayout.ISOMORPHIC_UP || layout == ScaleLayout.ISOMORPHIC_RIGHT) {
+                    // We could repurpose the shift parameters as fixed semitone deltas dx, dy:
+                    //  this.matrix[index] = x * shift + y * semitoneShift - 4;
+
                 } else if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
                     final int step = x * 2 + y * shift;
                     this.matrix[index] = 12 * (step / len) + intervals[step % len];

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -60,11 +60,7 @@ class ScaleGrid
                 final int x = isUp ? column : row;
                 final int index = row * cols + column;
 
-                if (layout == ScaleLayout.ISOMORPHIC_UP || layout == ScaleLayout.ISOMORPHIC_RIGHT) {
-                    // We could repurpose the shift parameters as fixed semitone deltas dx, dy:
-                    //  this.matrix[index] = x * shift + y * semitoneShift - 4;
-
-                } else if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
+                if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
                     final int step = x * 2 + y * shift;
                     this.matrix[index] = 12 * (step / len) + intervals[step % len];
                 } else {

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -52,6 +52,25 @@ class ScaleGrid
         final boolean isUp = orientation == Orientation.ORIENT_UP;
         final int centerOffset = layout == ScaleLayout.EIGHT_UP_CENTER || layout == ScaleLayout.EIGHT_RIGHT_CENTER ? -3 : 0;
 
+        // Axis deltas, in scale steps.
+        int dx = 1;
+        int dy = shift;
+
+        // Fix 8th layout for scales which do not have 7 steps
+        if (shift == 7) {
+            dy = len;
+        }
+
+        if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
+            dx = 2;
+            // Staggered layout steps right by + 2, so on the row above a nice symmetry is produced by octave - 2.
+            // Divide until shift is odd to evenly distribute the full scale and ensure all steps are included.
+            dy = len - 2;
+            while (dy > 1 && (dy & 1) == 0) {
+                dy /= 2;
+            }
+        }
+
         for (int row = 0; row < rows; row++)
         {
             for (int column = 0; column < cols; column++)
@@ -60,26 +79,16 @@ class ScaleGrid
                 final int x = isUp ? column : row;
                 final int index = row * cols + column;
 
-                if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
-                    final int step = x * 2 + y * shift;
-                    this.matrix[index] = 12 * (step / len) + intervals[step % len];
-                } else {
-                    int s = shift;
-                    // Fix 8th layout for scales which do not have 7 steps
-                    if (shift == 7)
-                        s = len;
-                    int offset = y * s + x + centerOffset;
+                int offset = y * dy + x * dx + centerOffset;
+                int oct = offset / len;
 
-                    int oct = offset / len;
-
-                    // Fix negative values introduced by centerOffset
-                    if (offset < 0) {
-                        offset = len + offset;
-                        oct = offset / len - 1;
-                    }
-
-                    this.matrix[index] = oct * 12 + intervals[offset % len];
+                // Fix negative values introduced by centerOffset
+                if (offset < 0) {
+                    offset = len + offset;
+                    oct = offset / len - 1;
                 }
+
+                this.matrix[index] = oct * 12 + intervals[offset % len];
                 this.chromatic[index] = y * semitoneShift + x;
             }
         }

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -60,13 +60,9 @@ class ScaleGrid
                 final int x = isUp ? column : row;
                 final int index = row * cols + column;
 
-                if (layout == ScaleLayout.ISOMORPHIC_UP || layout == ScaleLayout.ISOMORPHIC_RIGHT) {
-                    // We could repurpose the shift parameters as fixed semitone deltas dx, dy:
-                    // this.matrix[index] = x * shift + y * semitoneShift - 4;
-                    // But that is not very flexible without dedicated configuration for dx, dy.
-                    // Provide at least some alternatives for now by using the selected scale's first and median steps
-                    // as deltas.
-                    this.matrix[index] = x * intervals[1] + y * intervals[intervals.length / 2] - 4;
+                if (layout == ScaleLayout.FOLDED_UP || layout == ScaleLayout.FOLDED_RIGHT) {
+                    final int step = x + y * shift;
+                    this.matrix[index] = 12 * (step / len) + intervals[step % len];
                 } else if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
                     final int step = x * 2 + y * shift;
                     this.matrix[index] = 12 * (step / len) + intervals[step % len];

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleGrid.java
@@ -57,16 +57,17 @@ class ScaleGrid
         int dy = shift;
 
         // Fix 8th layout for scales which do not have 7 steps
-        if (shift == 7) {
+        if (shift == 7)
             dy = len;
-        }
 
-        if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT) {
+        if (layout == ScaleLayout.STAGGERED_UP || layout == ScaleLayout.STAGGERED_RIGHT)
+        {
             dx = 2;
             // Staggered layout steps right by + 2, so on the row above a nice symmetry is produced by octave - 2.
             // Divide until shift is odd to evenly distribute the full scale and ensure all steps are included.
             dy = len - 2;
-            while (dy > 1 && (dy & 1) == 0) {
+            while (dy > 1 && (dy & 1) == 0)
+            {
                 dy /= 2;
             }
         }
@@ -83,7 +84,8 @@ class ScaleGrid
                 int oct = offset / len;
 
                 // Fix negative values introduced by centerOffset
-                if (offset < 0) {
+                if (offset < 0)
+                {
                     offset = len + offset;
                     oct = offset / len - 1;
                 }

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -30,10 +30,12 @@ public enum ScaleLayout
     /** Eighth steps centered upwards. */
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
-    EIGHT_RIGHT_CENTER("8th > centered");
+    EIGHT_RIGHT_CENTER("8th > centered"),
 
+    ISOMORPHIC_UP("Isomorphic ^"),
+    ISOMORPHIC_RIGHT("Isomorphic >");
 
-    private static final String [] scaleLayoutNames = new String [10];
+    private static final String [] scaleLayoutNames = new String [12];
     static
     {
         final ScaleLayout [] values = ScaleLayout.values ();

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -31,11 +31,11 @@ public enum ScaleLayout
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
     EIGHT_RIGHT_CENTER("8th > centered"),
-    /** Upwards by a fixed number of semitones. */
-    ISOMORPHIC_UP("Isomorphic ^"),
-    /** Same as ISOMORPHIC_UP but with rows and columns transposed. */
-    ISOMORPHIC_RIGHT("Isomorphic >"),
-    /** Upward by one less than half the scale. */
+    /** Upward by one less than half the scale, right by scale steps. */
+    FOLDED_UP("Folded ^"),
+    /** Same as FOLDED_UP but with rows and columns transposed. */
+    FOLDED_RIGHT("Folded >"),
+    /** Upward by one less than half the scale (ensuring odd), right by two scale steps. */
     STAGGERED_UP("Staggered ^"),
     /** Same as STAGGERED_UP but with rows and columns transposed. */
     STAGGERED_RIGHT("Staggered >");

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -31,10 +31,6 @@ public enum ScaleLayout
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
     EIGHT_RIGHT_CENTER("8th > centered"),
-    /** Upward by one less than half the scale, right by scale steps. */
-    FOLDED_UP("Folded ^"),
-    /** Same as FOLDED_UP but with rows and columns transposed. */
-    FOLDED_RIGHT("Folded >"),
     /** Upward by one less than half the scale (ensuring odd), right by two scale steps. */
     STAGGERED_UP("Staggered ^"),
     /** Same as STAGGERED_UP but with rows and columns transposed. */

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -31,14 +31,20 @@ public enum ScaleLayout
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
     EIGHT_RIGHT_CENTER("8th > centered"),
-
+    /** Upwards by a fixed number of semitones. */
     ISOMORPHIC_UP("Isomorphic ^"),
-    ISOMORPHIC_RIGHT("Isomorphic >");
+    /** Same as ISOMORPHIC_UP but with rows and columns transposed. */
+    ISOMORPHIC_RIGHT("Isomorphic >"),
+    /** Upward by one less than half the scale. */
+    STAGGERED_UP("Staggered ^"),
+    /** Same as STAGGERED_UP but with rows and columns transposed. */
+    STAGGERED_RIGHT("Staggered >");
 
-    private static final String [] scaleLayoutNames = new String [12];
+    private static final String [] scaleLayoutNames;
     static
     {
         final ScaleLayout [] values = ScaleLayout.values ();
+        scaleLayoutNames = new String [values.length];
         for (int i = 0; i < values.length; i++)
             scaleLayoutNames[i] = values[i].name;
     }

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -31,9 +31,9 @@ public enum ScaleLayout
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
     EIGHT_RIGHT_CENTER("8th > centered"),
-    /** Upward by five scale steps, right by two steps. */
+    /** Upward by ~five steps and rightward by two steps. (dx = 2, dy = 5) */
     STAGGERED_UP("Staggered ^"),
-    /** Same as STAGGERED_UP but with rows and columns transposed. */
+    /** Rightward by ~five steps and upward by two steps. (dx = 5, dy = 2) */
     STAGGERED_RIGHT("Staggered >");
 
     private static final String [] scaleLayoutNames;

--- a/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
+++ b/src/main/java/de/mossgrabers/framework/scale/ScaleLayout.java
@@ -31,7 +31,7 @@ public enum ScaleLayout
     EIGHT_UP_CENTER("8th ^ centered"),
     /** Eighth steps centered to the right. */
     EIGHT_RIGHT_CENTER("8th > centered"),
-    /** Upward by one less than half the scale (ensuring odd), right by two scale steps. */
+    /** Upward by five scale steps, right by two steps. */
     STAGGERED_UP("Staggered ^"),
     /** Same as STAGGERED_UP but with rows and columns transposed. */
     STAGGERED_RIGHT("Staggered >");

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -348,10 +348,6 @@ public class Scales
             case EIGHT_RIGHT_CENTER:
                 this.setPlayShift (7, 12);
                 break;
-            case FOLDED_UP:
-            case FOLDED_RIGHT:
-                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
-                break;
             case STAGGERED_UP:
             case STAGGERED_RIGHT:
                 this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -350,7 +350,8 @@ public class Scales
                 break;
             case STAGGERED_UP:
             case STAGGERED_RIGHT:
-                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
+                this.setPlayShift (5, 5);
+//                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
 //                this.setPlayShift (((this.selectedScale.getIntervals().length / 2 + 1) & ~1) - 1, 5);
                 break;
         }

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -350,9 +350,9 @@ public class Scales
                 break;
             case STAGGERED_UP:
             case STAGGERED_RIGHT:
-                this.setPlayShift (5, 5);
-//                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
-//                this.setPlayShift (((this.selectedScale.getIntervals().length / 2 + 1) & ~1) - 1, 5);
+                // Note, scaleShift is dynamically determined by ScaleGrid depending on scale. It isn't calculated
+                // here because scale could change without a subsequent layout change to refresh the computed value.
+                this.setPlayShift (0, 5);
                 break;
         }
     }

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -348,6 +348,10 @@ public class Scales
             case EIGHT_RIGHT_CENTER:
                 this.setPlayShift (7, 12);
                 break;
+            case ISOMORPHIC_UP:
+            case ISOMORPHIC_RIGHT:
+                this.setPlayShift (2, 5);
+                break;
         }
     }
 

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -348,14 +348,14 @@ public class Scales
             case EIGHT_RIGHT_CENTER:
                 this.setPlayShift (7, 12);
                 break;
-            case ISOMORPHIC_UP:
-            case ISOMORPHIC_RIGHT:
-                // TODO: This would be more useful if user could configure semitone deltas dx, dy.
-                this.setPlayShift (2, 5);
+            case FOLDED_UP:
+            case FOLDED_RIGHT:
+                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
                 break;
             case STAGGERED_UP:
             case STAGGERED_RIGHT:
                 this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
+//                this.setPlayShift (((this.selectedScale.getIntervals().length / 2 + 1) & ~1) - 1, 5);
                 break;
         }
     }

--- a/src/main/java/de/mossgrabers/framework/scale/Scales.java
+++ b/src/main/java/de/mossgrabers/framework/scale/Scales.java
@@ -350,7 +350,12 @@ public class Scales
                 break;
             case ISOMORPHIC_UP:
             case ISOMORPHIC_RIGHT:
+                // TODO: This would be more useful if user could configure semitone deltas dx, dy.
                 this.setPlayShift (2, 5);
+                break;
+            case STAGGERED_UP:
+            case STAGGERED_RIGHT:
+                this.setPlayShift (this.selectedScale.getIntervals().length / 2 - 1, 5);
                 break;
         }
     }


### PR DESCRIPTION
This feature creates a new "Staggered" scale layout which reveals harmonic relationships and is very playable for all scales including the chromatic scale. In common scales like major & minor, chords and arpeggios take on regular shapes that can be played and cycled across octaves quickly with simple finger runs. When the chromatic scale is staggered, harmonically related notes cluster together, making common scales easy to play while preserving the full chromatic palette.