### PR TITLE
MCU button remap options. Created for the xTouch Mini, but can be useful for other controllers.

### DIFF
--- a/src/main/java/de/mossgrabers/bitwig/framework/daw/data/CursorDeviceImpl.java
+++ b/src/main/java/de/mossgrabers/bitwig/framework/daw/data/CursorDeviceImpl.java
@@ -174,7 +174,7 @@ public class CursorDeviceImpl extends SpecificDeviceImpl implements ICursorDevic
     public void swapWithPrevious ()
     {
         final int position = this.getPosition ();
-        if (position == 0)
+        if (position <= 0) // had an instance where it was < 0
             return;
         final Device prevDevice = this.largeDeviceBank.getItemAt (position - 1);
         this.device.afterDeviceInsertionPoint ().moveDevices (prevDevice);

--- a/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUConfiguration.java
@@ -63,6 +63,10 @@ public class MCUConfiguration extends AbstractConfiguration
     public static final Integer       X_TOUCH_DISPLAY_COLORS                  = Integer.valueOf (66);
     /** Use 7 characters instead of 6 and a space character. */
     public static final Integer       USE_7_CHARACTERS                        = Integer.valueOf (67);
+    /** AG! Alternate mappings */
+    public static final Integer       REMAP_SOLO_TO_SHIFT                     = Integer.valueOf (68);
+    public static final Integer       REMAP_CLICK_TO_OPTION                   = Integer.valueOf (69);
+    public static final Integer       REMAP_EQ_INST_TO_DEVICE_PAGE_LEFT_RIGHT = Integer.valueOf (70);
 
     /** Use a Function button to switch to previous mode. */
     public static final int           FOOTSWITCH_2_PREV_MODE                  = 15;
@@ -84,6 +88,7 @@ public class MCUConfiguration extends AbstractConfiguration
 
     private static final String       DEVICE_SELECT                           = "<Select a profile>";
     private static final String       DEVICE_BEHRINGER_X_TOUCH                = "Behringer X-Touch";
+    private static final String       DEVICE_BEHRINGER_X_TOUCH_MINI           = "Behringer X-Touch Mini";
     private static final String       DEVICE_BEHRINGER_X_TOUCH_ONE            = "Behringer X-Touch One";
     private static final String       DEVICE_ICON_PLATFORM_M                  = "icon Platform M / M+";
     private static final String       DEVICE_ICON_QCON_PRO_X                  = "icon QConPro X";
@@ -95,6 +100,7 @@ public class MCUConfiguration extends AbstractConfiguration
         DEVICE_SELECT,
         DEVICE_BEHRINGER_X_TOUCH,
         DEVICE_BEHRINGER_X_TOUCH_ONE,
+        DEVICE_BEHRINGER_X_TOUCH_MINI,
         DEVICE_ICON_PLATFORM_M,
         DEVICE_ICON_QCON_PRO_X,
         DEVICE_MACKIE_MCU_PRO,
@@ -200,6 +206,11 @@ public class MCUConfiguration extends AbstractConfiguration
     private boolean                   masterVuMeter;
     private boolean                   displayColors;
     private boolean                   use7Characters;
+    //AG!
+    private boolean                   remapSoloToShift;
+    private boolean                   remapClickToOption;
+    private boolean                   remapEqInstToDevicePageLeftRight;
+
     private boolean                   touchChannel;
     private boolean                   touchChannelVolumeMode;
     private final int []              assignableFunctions                     = new int [7];
@@ -279,6 +290,17 @@ public class MCUConfiguration extends AbstractConfiguration
         this.activateBrowserSettings (globalSettings);
     }
 
+    // AG!
+    public boolean isRemappedSoloToShift() {
+        return this.remapSoloToShift;
+    }
+    public boolean isRemappedClickToOption() {
+        return this.remapClickToOption;
+    }
+    public boolean isRemappedEqInstToDevicePageLeftRight() {
+        //this.host.println("EQ/Inst Remapped: " + this.remapEqInstToDevicePageLeftRight);
+        return this.remapEqInstToDevicePageLeftRight;
+    }
 
     private void activateHardwareSettings (final ISettingsUI settingsUI)
     {
@@ -370,6 +392,31 @@ public class MCUConfiguration extends AbstractConfiguration
         });
         this.isSettingActive.add (USE_7_CHARACTERS);
 
+        //AG! Alternate mappings
+        
+        final IEnumSetting remapSoloToShiftSetting = settingsUI.getEnumSetting ("Remap Solo to Shit", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
+        remapSoloToShiftSetting.addValueObserver (value -> {
+            this.remapSoloToShift = "On".equals (value);
+            this.notifyObservers (REMAP_SOLO_TO_SHIFT);
+        });
+        this.isSettingActive.add (REMAP_SOLO_TO_SHIFT);
+
+        final IEnumSetting remapClickToOptionSetting = settingsUI.getEnumSetting ("Remap Click to Option", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
+        remapClickToOptionSetting.addValueObserver (value -> {
+            this.remapClickToOption = "On".equals (value);
+            this.notifyObservers (REMAP_CLICK_TO_OPTION);
+        });
+        this.isSettingActive.add (REMAP_CLICK_TO_OPTION);
+
+        final IEnumSetting remapEqInstToDevicePageLeftRightSetting = settingsUI.getEnumSetting ("Remap Eq/Inst to Device Page Left/Right", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
+        remapEqInstToDevicePageLeftRightSetting.addValueObserver (value -> {
+            this.remapEqInstToDevicePageLeftRight = "On".equals (value);
+            this.notifyObservers (REMAP_EQ_INST_TO_DEVICE_PAGE_LEFT_RIGHT);
+        });
+        this.isSettingActive.add (REMAP_EQ_INST_TO_DEVICE_PAGE_LEFT_RIGHT);
+
+
+
         // Activate at the end, so all settings are created
         profileSetting.addValueObserver (value -> {
             switch (value)
@@ -388,6 +435,9 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[0]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[0]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
                     break;
 
                 case DEVICE_BEHRINGER_X_TOUCH:
@@ -404,6 +454,9 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[1]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[1]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
                     break;
 
                 case DEVICE_BEHRINGER_X_TOUCH_ONE:
@@ -420,6 +473,9 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[0]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[1]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
                     break;
 
                 case DEVICE_ICON_PLATFORM_M:
@@ -436,6 +492,9 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[0]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[0]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
                     break;
 
                 case DEVICE_ICON_QCON_PRO_X:
@@ -452,6 +511,9 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[1]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[0]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[0]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
                     break;
 
                 case DEVICE_ZOOM_R16:
@@ -468,6 +530,28 @@ public class MCUConfiguration extends AbstractConfiguration
                     masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
                     displayColorsSetting.set (ON_OFF_OPTIONS[0]);
                     use7CharactersSetting.set (ON_OFF_OPTIONS[0]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[0]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[0]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[0]);
+                    break;
+
+                case DEVICE_BEHRINGER_X_TOUCH_MINI:
+                    hasDisplay1Setting.set (ON_OFF_OPTIONS[0]);
+                    hasDisplay2Setting.set (ON_OFF_OPTIONS[0]);
+                    hasSegmentDisplaySetting.set (ON_OFF_OPTIONS[0]);
+                    hasAssignmentDisplaySetting.set (ON_OFF_OPTIONS[0]);
+                    this.hasMotorFadersSetting.set (ON_OFF_OPTIONS[0]);
+                    hasOnly1FaderSetting.set (ON_OFF_OPTIONS[0]);
+                    this.displayTrackNamesSetting.set (ON_OFF_OPTIONS[0]);
+                    useVertZoomForModesSetting.set (ON_OFF_OPTIONS[0]);
+                    this.useFadersAsKnobsSetting.set (ON_OFF_OPTIONS[0]);
+                    this.setVUMetersEnabled (false);
+                    masterVuMeterSetting.set (ON_OFF_OPTIONS[0]);
+                    displayColorsSetting.set (ON_OFF_OPTIONS[0]);
+                    use7CharactersSetting.set (ON_OFF_OPTIONS[0]);
+                    remapSoloToShiftSetting.set(ON_OFF_OPTIONS[1]);
+                    remapClickToOptionSetting.set(ON_OFF_OPTIONS[1]);
+                    remapEqInstToDevicePageLeftRightSetting.set(ON_OFF_OPTIONS[1]);
                     break;
 
                 default:

--- a/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUControllerSetup.java
@@ -497,14 +497,6 @@ public class MCUControllerSetup extends AbstractControllerSetup<MCUControlSurfac
                         project.clearSolo ();
                 }, 0, MCUControlSurface.MCU_SOLO, () -> surface.isShiftPressed () ? project.hasMute () : project.hasSolo ());
                 this.addButton (surface, ButtonID.OVERDUB, "Overdub", new OverdubCommand<> (this.model, surface), 0, MCUControlSurface.MCU_REPLACE, () -> (surface.getButton (ButtonID.SHIFT).isPressed () ? t.isLauncherOverdub () : t.isArrangerOverdub ()));
-                
-                // AG!
-                // if( this.configuration.isRemappedSoloToShift() ) {
-                //     //
-                //     // REMAP TAP TEMPO TO BANK RIGHT
-                //     //
-                //     this.addButton (surface, ButtonID.TAP_TEMPO, "Bank Right", new MCUMoveTrackBankCommand (this.model, surface, false, false), MCUControlSurface.MCU_NUDGE);
-                // } else
                 this.addButton (surface, ButtonID.TAP_TEMPO, "Tap Tempo", new TapTempoCommand<> (this.model, surface), 0, MCUControlSurface.MCU_NUDGE);
                 
                 this.addButton (surface, ButtonID.DUPLICATE, "Duplicate", (event, velocity) -> {
@@ -532,10 +524,6 @@ public class MCUControllerSetup extends AbstractControllerSetup<MCUControlSurfac
                 // Only MCU
                 this.addButton (surface, ButtonID.SAVE, "Save", new SaveCommand<> (this.model, surface), MCUControlSurface.MCU_SAVE);
 
-                // if( this.configuration.isRemappedSoloToShift() ) {
-                //     // REMAP MARKER TO BANK LEFT
-                //     this.addButton (surface, ButtonID.MARKER, "Marker > Bank Left", new MCUMoveTrackBankCommand (this.model, surface, false, true), MCUControlSurface.MCU_MARKER);
-                // } else
                 this.addButton (surface, ButtonID.MARKER, "Marker", new MarkerCommand<> (this.model, surface), 0, MCUControlSurface.MCU_MARKER, () -> surface.getButton (ButtonID.SHIFT).isPressed () ? this.model.getArranger ().areCueMarkersVisible () : modeManager.isActive (Modes.MARKERS));
                 
                 this.addButton (surface, ButtonID.TOGGLE_VU, "Toggle VU", new ToggleVUCommand<> (this.model, surface), 0, MCUControlSurface.MCU_EDIT, () -> this.configuration.isEnableVUMeters ());

--- a/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/mcu/MCUControllerSetup.java
@@ -486,7 +486,6 @@ public class MCUControllerSetup extends AbstractControllerSetup<MCUControlSurfac
 
                 // Utilities
                 this.addButton (surface, ButtonID.BROWSE, "Browse", new BrowserCommand<> (this.model, surface), 0, MCUControlSurface.MCU_USER, () -> modeManager.isActive (Modes.BROWSER));
-                this.addButton (surface, ButtonID.METRONOME, "Metronome", new MetronomeCommand<> (this.model, surface, false), 0, MCUControlSurface.MCU_CLICK, () -> surface.getButton (ButtonID.SHIFT).isPressed () ? t.isMetronomeTicksOn () : t.isMetronomeOn ());
 
                 final IProject project = this.model.getProject ();
                 this.addButton (surface, ButtonID.GROOVE, "Solo Defeat", (event, velocity) -> {
@@ -913,33 +912,5 @@ public class MCUControllerSetup extends AbstractControllerSetup<MCUControlSurfac
     protected BindType getTriggerBindType (final ButtonID buttonID)
     {
         return BindType.NOTE;
-    }
-
-
-    /**
-     * Handle a track selection change.
-     *
-     * @param isSelected Has the track been selected?
-     */
-    private void handleTrackChange (final boolean isSelected)
-    {
-        if (!isSelected)
-            return;
-
-        final ModeManager modeManager = this.getSurface ().getModeManager ();
-        if (modeManager.isActive (Modes.MASTER) && !this.model.getMasterTrack ().isSelected ())
-        {
-            if (Modes.isTrackMode (modeManager.getPreviousID ()))
-                modeManager.restore ();
-            else
-                modeManager.setActive (Modes.TRACK);
-        }
-    }
-
-
-    private static int getButtonColor (final MCUControlSurface surface, final ButtonID buttonID)
-    {
-        final IMode mode = surface.getModeManager ().getActive ();
-        return mode == null ? 0 : mode.getButtonColor (buttonID);
     }
 }


### PR DESCRIPTION
1. Added a new MCU controller type: xTouch Mini - for remapping buttons configuration
2. Added three button remap options:
    1. SOLO to SHIFT
    2. CLICK to OPTION
    3. Device mode EQ and INST to PAGE_LEFT / RIGHT

Once I was able to change the device pages, in order to control parameters without having to switch away from the controller, I needed SHIFT to control the speed/coarseness of the encoders. By default, I use a fast speed of -10 to quickly get in the ballpark, and on SHIFT change the speed to -100, for fine parameter adjustments.

I don't find the OPTION as useful as SHIFT, but it's more useful than the default CLICK mapping.