### PR TITLE
ButtonID.isInRange checked only the upper bound

### DIFF
--- a/src/main/java/de/mossgrabers/framework/controller/ButtonID.java
+++ b/src/main/java/de/mossgrabers/framework/controller/ButtonID.java
@@ -867,6 +867,6 @@ public enum ButtonID
      */
     public static boolean isInRange (final ButtonID buttonID, final ButtonID firstButtonID, final int length)
     {
-        return buttonID != null && ButtonID.get (firstButtonID, length - 1).ordinal () - buttonID.ordinal () >= 0;
+        return buttonID != null && ButtonID.get (firstButtonID, length - 1).ordinal () >= buttonID.ordinal () && buttonID.ordinal () >= firstButtonID.ordinal ();
     }
 }


### PR DESCRIPTION
Only tested with an Akai Fire on MacOS.

Thus buttons like ALT were treated as pads and a ColorIndexException was thrown. I discovered that issue as my Akai Fire stopped working after the latest upgrade.

Bisecting showed that it was introduced with the following commit.

commit a0ced425e343977bd53e74bcf06b4a8bf4fe06c0 (HEAD)
Author: git-moss <juergen.mossgraber@googlemail.com>
Date:   Sun Oct 2 14:56:15 2022 +0200

    Finished Yaeltex Turn support. Updated manual.