### PR TITLE
show available pads in clip view

### DIFF
--- a/src/main/java/de/mossgrabers/controller/ableton/push/view/ClipView.java
+++ b/src/main/java/de/mossgrabers/controller/ableton/push/view/ClipView.java
@@ -82,7 +82,7 @@ public class ClipView extends AbstractSequencerView<PushControlSurface, PushConf
             final IClip clip = this.getClip ();
             clip.setLoopStart (newStart);
             clip.setLoopLength ((int) ((end - start) * quartersPerPad));
-            clip.setPlayRange (newStart, end * quartersPerPad);
+            clip.setPlayStart(newStart);
 
             this.loopPadPressed = -1;
         }
@@ -103,15 +103,22 @@ public class ClipView extends AbstractSequencerView<PushControlSurface, PushConf
         final double start = clip.getLoopStart ();
         final int loopStartPad = (int) Math.floor (Math.max (0, start) / quartersPerPad);
         final int loopEndPad = (int) Math.ceil (Math.min (maxQuarters, start + clip.getLoopLength ()) / quartersPerPad);
+        final int clipEndPad = (int) Math.ceil (Math.min (maxQuarters, clip.getPlayEnd()) / quartersPerPad);
         final boolean isPush2 = this.surface.getConfiguration ().isPush2 ();
         final int white = isPush2 ? PushColorManager.PUSH2_COLOR2_WHITE : PushColorManager.PUSH1_COLOR2_WHITE;
         final int green = isPush2 ? PushColorManager.PUSH2_COLOR2_GREEN : PushColorManager.PUSH1_COLOR2_GREEN;
         final int off = isPush2 ? PushColorManager.PUSH2_COLOR_BLACK : PushColorManager.PUSH1_COLOR_BLACK;
+        final int available = isPush2 ? PushColorManager.PUSH2_COLOR2_GREY_MD : PushColorManager.PUSH1_COLOR2_GREY_MD;
+
         for (int pad = 0; pad < 64; pad++)
         {
             final int color;
-            if (pad >= loopStartPad && pad < loopEndPad)
+            if (pad < loopStartPad)
+                color = available;
+            else if (pad < loopEndPad)
                 color = pad == currentMeasure ? green : white;
+            else if (pad < clipEndPad)
+                color = available;
             else
                 color = off;
             this.surface.getPadGrid ().lightEx (pad % 8, pad / 8, color, -1, false);


### PR DESCRIPTION
Hi, 
we had a conversation about this feature: [read discussion on YT](https://www.youtube.com/watch?v=kTG4oXqlaj4&lc=Ugycuy-87YKHe8RuO7J4AaABAg).
I managed to get this working.
We can safely assume that 0.0 is the clip start, so pads before the loop can be lit as availalbe for looping. Regarding the clip end, it isn't affected by the loop settings (if the loop end doesn't go beyond the clip end). 
[video demonstration](https://photos.app.goo.gl/7M28gGNct61aptAGA)