### PR TITLE
Implement 'Write' as 'Latch' behavior for Yamaha DM3 in Steinberg mode

### DIFF
--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
@@ -190,7 +190,7 @@ public class HUIConfiguration extends AbstractConfiguration
 
         this.yamahaWriteHackSetting = settingsUI.getEnumSetting ("WRITE selects current automation mode", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
         this.yamahaWriteHackSetting.addValueObserver (value -> {
-            this.yamahaWriteHack = "Off".equals (value);
+            this.yamahaWriteHack = "On".equals (value);
             this.notifyObservers (YAMAHA_WRITE_HACK);
         });
 
@@ -311,7 +311,6 @@ public class HUIConfiguration extends AbstractConfiguration
     public boolean isYamahaWriteHacked ()
     {
         return this.yamahaWriteHack;
-        /* return true; */
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
@@ -34,6 +34,8 @@ public class HUIConfiguration extends AbstractConfiguration
     public static final Integer    HAS_MOTOR_FADERS        = Integer.valueOf (54);
     /** Select the channel when touching it's fader. */
     private static final Integer   TOUCH_CHANNEL           = Integer.valueOf (55);
+    /** Make the WRITE button select the current automation mode (hack for the Yamaha DM3) */
+    public static final Integer    YAMAHA_WRITE_HACK      = Integer.valueOf (56);
 
     /** Use a Function button to switch to previous mode. */
     public static final int        FOOTSWITCH_2_PREV_MODE  = 15;
@@ -43,7 +45,8 @@ public class HUIConfiguration extends AbstractConfiguration
     public static final int        SHOW_MARKER_MODE        = 17;
 
     private static final String    DEVICE_SELECT           = "<Select a profile>";
-    private static final String    DEVICE_ICON_QCON_PRO_X  = "icon QConPro X";
+    private static final String    DEVICE_ICON_QCON_PRO_X  = "iCON QConPro X";
+    private static final String    DEVICE_YAMAHA_DM3  = "Yamaha DM3";
     private static final String    DEVICE_MACKIE_HUI       = "Mackie HUI";
     private static final String    DEVICE_NOVATION_SLMKIII = "Novation MkIII";
 
@@ -51,6 +54,7 @@ public class HUIConfiguration extends AbstractConfiguration
     {
         DEVICE_SELECT,
         DEVICE_ICON_QCON_PRO_X,
+        DEVICE_YAMAHA_DM3,        
         DEVICE_MACKIE_HUI,
         DEVICE_NOVATION_SLMKIII
     };
@@ -73,11 +77,13 @@ public class HUIConfiguration extends AbstractConfiguration
     private IEnumSetting           hasDisplay1Setting;
     private IEnumSetting           hasSegmentDisplaySetting;
     private IEnumSetting           hasMotorFadersSetting;
+    private IEnumSetting           yamahaWriteHackSetting;
 
     private boolean                zoomState;
     private boolean                hasDisplay1;
     private boolean                hasSegmentDisplay;
     private boolean                hasMotorFaders;
+    private boolean                yamahaWriteHack;
     private boolean                touchChannel;
     private boolean                sendPing;
 
@@ -151,6 +157,12 @@ public class HUIConfiguration extends AbstractConfiguration
                     this.setVUMetersEnabled (false);
                     break;
 
+                case DEVICE_YAMAHA_DM3:
+                    this.yamahaWriteHackSetting.set (ON_OFF_OPTIONS[1]);
+                    this.hasMotorFadersSetting.set (ON_OFF_OPTIONS[1]);
+                    this.setVUMetersEnabled (true);
+                    break;
+
                 default:
                     return;
             }
@@ -176,6 +188,12 @@ public class HUIConfiguration extends AbstractConfiguration
             this.notifyObservers (HAS_MOTOR_FADERS);
         });
 
+        this.yamahaWriteHackSetting = settingsUI.getEnumSetting ("WRITE selects current automation mode", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
+        this.yamahaWriteHackSetting.addValueObserver (value -> {
+            this.yamahaWriteHack = "Off".equals (value);
+            this.notifyObservers (YAMAHA_WRITE_HACK);
+        });
+
         final IEnumSetting sendPingSetting = settingsUI.getEnumSetting ("Send ping", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
         sendPingSetting.addValueObserver (value -> {
             this.sendPing = "On".equals (value);
@@ -185,6 +203,7 @@ public class HUIConfiguration extends AbstractConfiguration
         this.isSettingActive.add (HAS_DISPLAY1);
         this.isSettingActive.add (HAS_SEGMENT_DISPLAY);
         this.isSettingActive.add (HAS_MOTOR_FADERS);
+        this.isSettingActive.add (YAMAHA_WRITE_HACK);
         this.isSettingActive.add (SEND_PING);
     }
 
@@ -282,6 +301,17 @@ public class HUIConfiguration extends AbstractConfiguration
     public boolean hasMotorFaders ()
     {
         return this.hasMotorFaders;
+    }
+
+    /**
+     * Returns true if WRITE should select the current automation mode.
+     *
+     * @return True if WRITE should select the current automation mode.
+     */
+    public boolean isYamahaWriteHacked ()
+    {
+        return this.yamahaWriteHack;
+        /* return true; */
     }
 
 

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
@@ -188,7 +188,7 @@ public class HUIConfiguration extends AbstractConfiguration
             this.notifyObservers (HAS_MOTOR_FADERS);
         });
 
-        this.yamahaWriteHackSetting = settingsUI.getEnumSetting ("WRITE selects current automation mode", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
+        this.yamahaWriteHackSetting = settingsUI.getEnumSetting ("WRITE selects latch mode", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[0]);
         this.yamahaWriteHackSetting.addValueObserver (value -> {
             this.yamahaWriteHack = "On".equals (value);
             this.notifyObservers (YAMAHA_WRITE_HACK);
@@ -304,9 +304,9 @@ public class HUIConfiguration extends AbstractConfiguration
     }
 
     /**
-     * Returns true if WRITE should select the current automation mode.
+     * Returns true if WRITE should select latch mode (hack for the DM3.)
      *
-     * @return True if WRITE should select the current automation mode.
+     * @return True if WRITE should select latch mode (hack for the DM3.)
      */
     public boolean isYamahaWriteHacked ()
     {

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -401,9 +401,6 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_SENDMUTE, not supported
             // HUI_AUTO_ENABLE_SEND, not supported
             // HUI_AUTO_ENABLE_MUTE, not supported
-			if (this.configuration.isYamahaWriteHacked()) {
-				this.model.getHost().showNotification("Yamaha WRITE hack enabled.");
-			}
 				
             // Automation modes
             this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -401,7 +401,6 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_SENDMUTE, not supported
             // HUI_AUTO_ENABLE_SEND, not supported
             // HUI_AUTO_ENABLE_MUTE, not supported
-								
 			if (this.configuration.isYamahaWriteHacked()) {
 				this.model.getHost().showNotification("Yamaha WRITE hack enabled.");
 			}
@@ -411,8 +410,14 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
-/*            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.LATCH); */
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
+if (this.configuration.isYamahaWriteHacked()) {
+			this.model.getHost().showNotification("Setting to LATCH.");
+            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+} else {
+			this.model.getHost().showNotification("Setting to WRITE.");
+            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
+}
+             this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
 
             // Status
             // HUI_STATUS_PHASE, not supported
@@ -620,7 +625,7 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             surface.getButton (ButtonID.AUTOMATION_TRIM).setBounds (777.75, 272.25, 65.0, 39.75);
             surface.getButton (ButtonID.AUTOMATION_READ).setBounds (667.25, 272.25, 30.25, 39.75);
             surface.getButton (ButtonID.AUTOMATION_LATCH).setBounds (921.5, 272.25, 65.0, 39.75);
-/*            surface.getButton (ButtonID.AUTOMATION_WRITE).setBounds (705.0, 272.25, 65.0, 39.75); */
+            surface.getButton (ButtonID.AUTOMATION_WRITE).setBounds (705.0, 272.25, 65.0, 39.75);
             surface.getButton (ButtonID.AUTOMATION_TOUCH).setBounds (849.25, 272.25, 65.0, 39.75);
             surface.getButton (ButtonID.REC_ARM_ALL).setBounds (632.5, 225.5, 65.0, 39.75);
             surface.getButton (ButtonID.F1).setBounds (632.5, 178.25, 65.0, 39.75);

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -411,10 +411,8 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
 if (this.configuration.isYamahaWriteHacked()) {
-			this.model.getHost().showNotification("Setting to LATCH.");
             this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
 } else {
-			this.model.getHost().showNotification("Setting to WRITE.");
             this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
 }
              this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -401,13 +401,17 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_SENDMUTE, not supported
             // HUI_AUTO_ENABLE_SEND, not supported
             // HUI_AUTO_ENABLE_MUTE, not supported
-
+								
+			if (this.configuration.isYamahaWriteHacked()) {
+				this.model.getHost().showNotification("Yamaha WRITE hack enabled.");
+			}
+				
             // Automation modes
             this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
+/*            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.LATCH); */
             this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
 
             // Status
@@ -616,7 +620,7 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             surface.getButton (ButtonID.AUTOMATION_TRIM).setBounds (777.75, 272.25, 65.0, 39.75);
             surface.getButton (ButtonID.AUTOMATION_READ).setBounds (667.25, 272.25, 30.25, 39.75);
             surface.getButton (ButtonID.AUTOMATION_LATCH).setBounds (921.5, 272.25, 65.0, 39.75);
-            surface.getButton (ButtonID.AUTOMATION_WRITE).setBounds (705.0, 272.25, 65.0, 39.75);
+/*            surface.getButton (ButtonID.AUTOMATION_WRITE).setBounds (705.0, 272.25, 65.0, 39.75); */
             surface.getButton (ButtonID.AUTOMATION_TOUCH).setBounds (849.25, 272.25, 65.0, 39.75);
             surface.getButton (ButtonID.REC_ARM_ALL).setBounds (632.5, 225.5, 65.0, 39.75);
             surface.getButton (ButtonID.F1).setBounds (632.5, 178.25, 65.0, 39.75);


### PR DESCRIPTION
This pull request modifies the DrivenByMoss integration to make the "Write" button on the Yamaha DM3 control surface function as "Latch" mode when used with Bitwig Studio in Steinberg mode.

Currently, when the DM3 is set to Others mode for Bitwig integration, the "Write" automation mode does not provide feedback to the user on the DM3 control surface after engaging it with the "SEL" button. This change forces the "Write" button on the DM3 touchscreen to trigger "Latch" mode instead when the DM3 is used in Steinberg mode.

While not the ideal long-term solution, this workaround allows Bitwig users to write automation data in Latch mode using the DM3 hardware when operating in the Steinberg control mode.  

The modification is a temporary hack until more robust automation mode integration can be implemented for the DM3 across control modes.