### PR TITLE
Notify user on HUI device display when automation modes engaged

### DIFF
--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
@@ -34,6 +34,8 @@ public class HUIConfiguration extends AbstractConfiguration
     public static final Integer    HAS_MOTOR_FADERS        = Integer.valueOf (54);
     /** Select the channel when touching it's fader. */
     private static final Integer   TOUCH_CHANNEL           = Integer.valueOf (55);
+    /** Show the selected automation mode on the device upon selection. */
+    private static final Integer   AUTOMATION_NOTIFICATION    = Integer.valueOf (56);
 
     /** Use a Function button to switch to previous mode. */
     public static final int        FOOTSWITCH_2_PREV_MODE  = 15;
@@ -45,6 +47,7 @@ public class HUIConfiguration extends AbstractConfiguration
     private static final String    DEVICE_SELECT           = "<Select a profile>";
     private static final String    DEVICE_ICON_QCON_PRO_X  = "icon QConPro X";
     private static final String    DEVICE_MACKIE_HUI       = "Mackie HUI";
+    private static final String    DEVICE_YAMAHA_DM3       = "Yamaha DM3";
     private static final String    DEVICE_NOVATION_SLMKIII = "Novation MkIII";
 
     private static final String [] DEVICE_OPTIONS          =
@@ -52,6 +55,7 @@ public class HUIConfiguration extends AbstractConfiguration
         DEVICE_SELECT,
         DEVICE_ICON_QCON_PRO_X,
         DEVICE_MACKIE_HUI,
+        DEVICE_YAMAHA_DM3,
         DEVICE_NOVATION_SLMKIII
     };
 
@@ -73,11 +77,13 @@ public class HUIConfiguration extends AbstractConfiguration
     private IEnumSetting           hasDisplay1Setting;
     private IEnumSetting           hasSegmentDisplaySetting;
     private IEnumSetting           hasMotorFadersSetting;
+    private IEnumSetting           automationNotificationSetting;
 
     private boolean                zoomState;
     private boolean                hasDisplay1;
     private boolean                hasSegmentDisplay;
     private boolean                hasMotorFaders;
+    private boolean                automationNotification;    
     private boolean                touchChannel;
     private boolean                sendPing;
 
@@ -144,6 +150,14 @@ public class HUIConfiguration extends AbstractConfiguration
                     this.setVUMetersEnabled (true);
                     break;
 
+                case DEVICE_YAMAHA_DM3:
+                    this.hasDisplay1Setting.set (ON_OFF_OPTIONS[1]);
+                    this.hasSegmentDisplaySetting.set (ON_OFF_OPTIONS[1]);
+                    this.hasMotorFadersSetting.set (ON_OFF_OPTIONS[1]);
+                    this.automationNotificationSetting.set (ON_OFF_OPTIONS[1]);
+                    this.setVUMetersEnabled (true);
+                    break;
+
                 case DEVICE_NOVATION_SLMKIII:
                     this.hasDisplay1Setting.set (ON_OFF_OPTIONS[1]);
                     this.hasSegmentDisplaySetting.set (ON_OFF_OPTIONS[0]);
@@ -170,10 +184,10 @@ public class HUIConfiguration extends AbstractConfiguration
             this.notifyObservers (HAS_SEGMENT_DISPLAY);
         });
 
-        this.hasMotorFadersSetting = settingsUI.getEnumSetting ("Has motor faders", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
-        this.hasMotorFadersSetting.addValueObserver (value -> {
-            this.hasMotorFaders = "On".equals (value);
-            this.notifyObservers (HAS_MOTOR_FADERS);
+        this.automationNotificationSetting = settingsUI.getEnumSetting("Automation mode notifications", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
+        this.automationNotificationSetting.addValueObserver(value -> {
+            this.automationNotification = "On".equals(value);
+            this.notifyObservers(AUTOMATION_NOTIFICATION);
         });
 
         final IEnumSetting sendPingSetting = settingsUI.getEnumSetting ("Send ping", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
@@ -184,6 +198,7 @@ public class HUIConfiguration extends AbstractConfiguration
 
         this.isSettingActive.add (HAS_DISPLAY1);
         this.isSettingActive.add (HAS_SEGMENT_DISPLAY);
+        this.isSettingActive.add (AUTOMATION_NOTIFICATION);
         this.isSettingActive.add (HAS_MOTOR_FADERS);
         this.isSettingActive.add (SEND_PING);
     }
@@ -284,6 +299,15 @@ public class HUIConfiguration extends AbstractConfiguration
         return this.hasMotorFaders;
     }
 
+    /**
+     * Returns true if automation mode notifications are enabled.
+     *
+     * @return True if automation mode notifications are enabled.
+     */
+    public boolean shouldNotifyAutomationMode ()
+    {
+        return this.automationNotification;
+    }
 
     /**
      * Returns true if a ping message should be send every second to the HUI device.

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIConfiguration.java
@@ -190,10 +190,16 @@ public class HUIConfiguration extends AbstractConfiguration
             this.notifyObservers(AUTOMATION_NOTIFICATION);
         });
 
+        this.hasMotorFadersSetting = settingsUI.getEnumSetting("Has motor faders", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
+        this.hasMotorFadersSetting.addValueObserver(value -> {
+        this.hasMotorFaders = "On".equals(value);
+        this.notifyObservers(HAS_MOTOR_FADERS);
+        });
+        
         final IEnumSetting sendPingSetting = settingsUI.getEnumSetting ("Send ping", CATEGORY_HARDWARE_SETUP, ON_OFF_OPTIONS, ON_OFF_OPTIONS[1]);
         sendPingSetting.addValueObserver (value -> {
             this.sendPing = "On".equals (value);
-            this.notifyObservers (HAS_MOTOR_FADERS);
+            this.notifyObservers (SEND_PING);
         });
 
         this.isSettingActive.add (HAS_DISPLAY1);

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -252,9 +252,7 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             final ModeManager modeManager = surface.getModeManager ();
             final ITransport t = this.model.getTransport ();
             final IApplication application = this.model.getApplication ();
-            final boolean automationNotification = true;
 
-            display.notifyHUIDisplay("Initializing HUI #" + String.valueOf(index));
             // Channel commands
             for (int channel = 0; channel < 8; channel++)
             {
@@ -406,7 +404,7 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-            if (automationNotification)
+            if (this.configuration.shouldNotifyAutomationMode())
             {
                 this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
                 this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -404,24 +404,12 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-            if (this.configuration.shouldNotifyAutomationMode())
-            {
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
-            }
-            else
-            {
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
-            }
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);                
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
 
             // Status
             // HUI_STATUS_PHASE, not supported

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -36,6 +36,7 @@ import de.mossgrabers.framework.command.trigger.track.RecArmAllCommand;
 import de.mossgrabers.framework.command.trigger.track.RecArmCommand;
 import de.mossgrabers.framework.command.trigger.track.SelectCommand;
 import de.mossgrabers.framework.command.trigger.track.SoloCommand;
+import de.mossgrabers.controller.mackie.hui.command.trigger.HUIAutomationModeCommand;
 import de.mossgrabers.framework.command.trigger.transport.AutomationModeCommand;
 import de.mossgrabers.framework.command.trigger.transport.MetronomeCommand;
 import de.mossgrabers.framework.command.trigger.transport.PlayCommand;
@@ -247,11 +248,11 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
         for (int index = 0; index < this.numHUIDevices; index++)
         {
             final HUIControlSurface surface = this.getSurface (index);
-
+            final HUIDisplay display = (HUIDisplay) surface.getDisplay();
             final ModeManager modeManager = surface.getModeManager ();
             final ITransport t = this.model.getTransport ();
             final IApplication application = this.model.getApplication ();
-
+            display.notifyHUIDisplay("Initializing HUI #" + String.valueOf(index));
             // Channel commands
             for (int channel = 0; channel < 8; channel++)
             {
@@ -406,7 +407,9 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+//            this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
+
             this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
             this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
 

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -252,6 +252,8 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             final ModeManager modeManager = surface.getModeManager ();
             final ITransport t = this.model.getTransport ();
             final IApplication application = this.model.getApplication ();
+            final boolean automationNotification = true;
+
             display.notifyHUIDisplay("Initializing HUI #" + String.valueOf(index));
             // Channel commands
             for (int channel = 0; channel < 8; channel++)
@@ -404,18 +406,25 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
-//             this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
-this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
+            if (automationNotification)
+            {
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
+            }
+            else
+            {
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
+            }
+
             // Status
             // HUI_STATUS_PHASE, not supported
             // HUI_STATUS_MONITOR, not supported

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -404,15 +404,18 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
-//            this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
+//             this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
+this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
+this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
 this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
-
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
-            this.addButtonHUI (surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
-
+this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
+this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
             // Status
             // HUI_STATUS_PHASE, not supported
             // HUI_STATUS_MONITOR, not supported

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -404,24 +404,12 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-            if (this.configuration.shouldNotifyAutomationMode())
-            {
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
-            }
-            else
-            {
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
-                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
-            }
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
+            this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
 
             // Status
             // HUI_STATUS_PHASE, not supported

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/HUIControllerSetup.java
@@ -404,12 +404,24 @@ public class HUIControllerSetup extends AbstractControllerSetup<HUIControlSurfac
             // HUI_AUTO_ENABLE_MUTE, not supported
 
             // Automation modes
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);                
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
-            this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
+            if (this.configuration.shouldNotifyAutomationMode())
+            {
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new HUIAutomationModeCommand(AutomationMode.TRIM_READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode() == AutomationMode.TRIM_READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new HUIAutomationModeCommand(AutomationMode.READ, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode() == AutomationMode.READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new HUIAutomationModeCommand(AutomationMode.LATCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode() == AutomationMode.LATCH);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new HUIAutomationModeCommand(AutomationMode.WRITE, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode() == AutomationMode.WRITE);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new HUIAutomationModeCommand(AutomationMode.TOUCH, this.model, surface, display), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode() == AutomationMode.TOUCH);
+            }
+            else
+            {
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_OFF, "Off", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_OFF, () -> false);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TRIM, "Trim", new AutomationModeCommand<> (AutomationMode.TRIM_READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TRIM, () -> t.getAutomationWriteMode () == AutomationMode.TRIM_READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_READ, "Read", new AutomationModeCommand<> (AutomationMode.READ, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_READ, () -> t.getAutomationWriteMode () == AutomationMode.READ);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_LATCH, "Latch", new AutomationModeCommand<> (AutomationMode.LATCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_LATCH, () -> t.getAutomationWriteMode () == AutomationMode.LATCH);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_WRITE, "Write", new AutomationModeCommand<> (AutomationMode.WRITE, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_WRITE, () -> t.getAutomationWriteMode () == AutomationMode.WRITE);
+                this.addButtonHUI(surface, ButtonID.AUTOMATION_TOUCH, "Touch", new AutomationModeCommand<> (AutomationMode.TOUCH, this.model, surface), HUIControlSurface.HUI_AUTO_MODE_TOUCH, () -> t.getAutomationWriteMode () == AutomationMode.TOUCH);
+            }
 
             // Status
             // HUI_STATUS_PHASE, not supported

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
@@ -28,7 +28,7 @@ public class HUIAutomationModeCommand extends AutomationModeCommand<HUIControlSu
 
             final AutomationMode mode = this.model.getTransport().getAutomationWriteMode();
             if (mode == this.ourAutomationMode) {
-                this.display.notifyHUIDisplay(mode.name());
+                this.display.notifyHUIDisplay("Automation: " + mode.name());
             }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
@@ -11,22 +11,24 @@ import de.mossgrabers.framework.utils.ButtonEvent;
 public class HUIAutomationModeCommand extends AutomationModeCommand<HUIControlSurface, HUIConfiguration>
 {
     private final HUIDisplay display;
+    private final AutomationMode ourAutomationMode;
 
     public HUIAutomationModeCommand(final AutomationMode autoMode, final IModel model, final HUIControlSurface surface, final HUIDisplay display)
     {
         super(autoMode, model, surface);
+        this.ourAutomationMode = autoMode;
         this.display = display;
     }
+
 
     @Override
     public void executeNormal(final ButtonEvent event)
     {
         super.executeNormal(event);
 
-        if (event == ButtonEvent.DOWN)
-        {
             final AutomationMode mode = this.model.getTransport().getAutomationWriteMode();
-            this.display.notifyHUIDisplay("Automation mode: " + mode.name());
-        }
+            if (mode == this.ourAutomationMode) {
+                this.display.notifyHUIDisplay(mode.name());
+            }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
@@ -1,0 +1,32 @@
+package de.mossgrabers.controller.mackie.hui.command.trigger;
+
+import de.mossgrabers.controller.mackie.hui.HUIConfiguration;
+import de.mossgrabers.controller.mackie.hui.controller.HUIControlSurface;
+import de.mossgrabers.controller.mackie.hui.controller.HUIDisplay;
+import de.mossgrabers.framework.command.trigger.transport.AutomationModeCommand;
+import de.mossgrabers.framework.daw.IModel;
+import de.mossgrabers.framework.daw.constants.AutomationMode;
+import de.mossgrabers.framework.utils.ButtonEvent;
+
+public class HUIAutomationModeCommand extends AutomationModeCommand<HUIControlSurface, HUIConfiguration>
+{
+    private final HUIDisplay display;
+
+    public HUIAutomationModeCommand(final AutomationMode autoMode, final IModel model, final HUIControlSurface surface, final HUIDisplay display)
+    {
+        super(autoMode, model, surface);
+        this.display = display;
+    }
+
+    @Override
+    public void executeNormal(final ButtonEvent event)
+    {
+        super.executeNormal(event);
+
+        if (event == ButtonEvent.DOWN)
+        {
+            final AutomationMode mode = this.model.getTransport().getAutomationWriteMode();
+            this.display.notifyHUIDisplay("Automation mode: " + mode.name());
+        }
+    }
+}

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/command/trigger/HUIAutomationModeCommand.java
@@ -28,7 +28,9 @@ public class HUIAutomationModeCommand extends AutomationModeCommand<HUIControlSu
 
             final AutomationMode mode = this.model.getTransport().getAutomationWriteMode();
             if (mode == this.ourAutomationMode) {
-                this.display.notifyHUIDisplay("Automation: " + mode.name());
+                if (this.surface.getConfiguration().shouldNotifyAutomationMode()) {
+                    this.display.notifyHUIDisplay("Automation: " + mode.name());
+                }
             }
     }
 }

--- a/src/main/java/de/mossgrabers/controller/mackie/hui/controller/HUIDisplay.java
+++ b/src/main/java/de/mossgrabers/controller/mackie/hui/controller/HUIDisplay.java
@@ -81,6 +81,11 @@ public class HUIDisplay extends AbstractTextDisplay
     }
 
 
+    public void notifyHUIDisplay (final String message)
+    {
+        this.notifyOnDisplay(message);
+    }
+    
     /** {@inheritDoc} */
     @Override
     public void shutdown ()


### PR DESCRIPTION
These changes provide a (user-selectable) notification to the user on the HUI device display when an automation mode (Read/Touch/Latch/Write/Trim) is engaged.

While these changes were tested with a Yamaha DM3 mixer in DAW control mode (which doesn't provide any sort of feedback when automation is engaged), they could be useful for other devices.