### PR TITLE
Ignore Electra One pot touch commands if preset is offline

### DIFF
--- a/src/main/java/de/mossgrabers/controller/electra/one/controller/ElectraOneControlSurface.java
+++ b/src/main/java/de/mossgrabers/controller/electra/one/controller/ElectraOneControlSurface.java
@@ -665,20 +665,21 @@ public class ElectraOneControlSurface extends AbstractControlSurface<ElectraOneC
                 break;
 
             case EVENT_POT_TOUCH:
-                final int potID = data[SUB_CMD_START_POS + 1];
-                final int controlID = (data[SUB_CMD_START_POS + 3] << 7) + data[SUB_CMD_START_POS + 2];
-                if (potID < 0 || potID >= 12)
-                {
-                    this.host.error ("Touch event with knob ID outside of range: " + potID);
-                    return;
+                if (this.isOnline) {
+                    final int potID = data[SUB_CMD_START_POS + 1];
+                    final int controlID = (data[SUB_CMD_START_POS + 3] << 7) + data[SUB_CMD_START_POS + 2];
+                    if (potID < 0 || potID >= 12) {
+                        this.host.error("Touch event with knob ID outside of range: " + potID);
+                        return;
+                    }
+
+                    this.knobStates[potID] = data[SUB_CMD_START_POS + 4];
+
+                    final IMode active = this.modeManager.getActive();
+                    if (active instanceof final AbstractElectraOneMode electraMode)
+                        electraMode.setEditing(controlID, this.knobStates[potID] > 0);
+                    this.matchStates();
                 }
-
-                this.knobStates[potID] = data[SUB_CMD_START_POS + 4];
-
-                final IMode active = this.modeManager.getActive ();
-                if (active instanceof final AbstractElectraOneMode electraMode)
-                    electraMode.setEditing (controlID, this.knobStates[potID] > 0);
-                this.matchStates ();
                 break;
 
             default:


### PR DESCRIPTION
Hi,

I thought I would try coding up a simple solution to the problem I reported in #403 .  It seems to work OK in my local testing. It looks like other commands are already skipped if the DrivenByMoss preset is offline. 

Prevents Electra One pot touches from being processed by the Electra One controller script if the DrivenByMoss preset is not currently selected on the Electra One device. 
