### PR TITLE
Trigger Push play on button press

### DIFF
--- a/src/main/java/de/mossgrabers/controller/ableton/push/PushControllerSetup.java
+++ b/src/main/java/de/mossgrabers/controller/ableton/push/PushControllerSetup.java
@@ -555,7 +555,7 @@ public class PushControllerSetup extends AbstractControllerSetup<PushControlSurf
 
         final ITransport t = this.model.getTransport ();
 
-        this.addButton (ButtonID.PLAY, "Play", new PlayCommand<> (this.model, surface), PushControlSurface.PUSH_BUTTON_PLAY, t::isPlaying, PushColorManager.PUSH_BUTTON_STATE_PLAY_ON, PushColorManager.PUSH_BUTTON_STATE_PLAY_HI);
+        this.addButton (ButtonID.PLAY, "Play", new PlayCommand<> (this.model, surface, ButtonID.SELECT, ButtonEvent.DOWN), PushControlSurface.PUSH_BUTTON_PLAY, t::isPlaying, PushColorManager.PUSH_BUTTON_STATE_PLAY_ON, PushColorManager.PUSH_BUTTON_STATE_PLAY_HI);
 
         this.addButton (ButtonID.RECORD, "Record", new RecordCommand<> (this.model, surface), PushControlSurface.PUSH_BUTTON_RECORD, () -> {
 

--- a/src/main/java/de/mossgrabers/framework/command/trigger/AbstractDoubleTriggerCommand.java
+++ b/src/main/java/de/mossgrabers/framework/command/trigger/AbstractDoubleTriggerCommand.java
@@ -21,7 +21,8 @@ import de.mossgrabers.framework.utils.ButtonEvent;
  */
 public abstract class AbstractDoubleTriggerCommand<S extends IControlSurface<C>, C extends Configuration> extends AbstractTriggerCommand<S, C>
 {
-    private boolean restartFlag = false;
+    private final ButtonEvent executionEvent;
+    private boolean           restartFlag = false;
 
 
     /**
@@ -32,7 +33,22 @@ public abstract class AbstractDoubleTriggerCommand<S extends IControlSurface<C>,
      */
     protected AbstractDoubleTriggerCommand (final IModel model, final S surface)
     {
+        this (model, surface, ButtonEvent.UP);
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param model The model
+     * @param surface The surface
+     * @param executionEvent The button event on which to execute the single/double click action
+     */
+    protected AbstractDoubleTriggerCommand (final IModel model, final S surface, final ButtonEvent executionEvent)
+    {
         super (model, surface);
+
+        this.executionEvent = executionEvent;
     }
 
 
@@ -40,7 +56,7 @@ public abstract class AbstractDoubleTriggerCommand<S extends IControlSurface<C>,
     @Override
     public void executeNormal (final ButtonEvent event)
     {
-        if (event != ButtonEvent.UP || this.handleButtonCombinations ())
+        if (event != this.executionEvent || this.handleButtonCombinations ())
             return;
 
         if (this.restartFlag)

--- a/src/main/java/de/mossgrabers/framework/command/trigger/transport/PlayCommand.java
+++ b/src/main/java/de/mossgrabers/framework/command/trigger/transport/PlayCommand.java
@@ -49,7 +49,22 @@ public class PlayCommand<S extends IControlSurface<C>, C extends Configuration> 
      */
     public PlayCommand (final IModel model, final S surface, final ButtonID selectButtonID)
     {
-        super (model, surface);
+        this (model, surface, selectButtonID, ButtonEvent.UP);
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param model The model
+     * @param surface The surface
+     * @param selectButtonID The buttonID to use for the select button which triggers additional
+     *            button combinations
+     * @param executionEvent The button event on which to execute the single/double click action
+     */
+    public PlayCommand (final IModel model, final S surface, final ButtonID selectButtonID, final ButtonEvent executionEvent)
+    {
+        super (model, surface, executionEvent);
 
         this.selectButtonID = selectButtonID;
         this.transport = this.model.getTransport ();


### PR DESCRIPTION
## Summary
- Allow double-trigger commands to execute on a configurable button event while keeping the default on release.
- Configure the Push play button to execute on button press.

## Motivation
Push play currently inherits release-triggered double-click handling, so transport playback starts only after the Play button is released. Executing Push play on press makes transport start feel more immediate while preserving existing release-triggered behavior for other controllers.

## Validation
- mvn -DskipTests package
- Manual Push 2/Bitwig check with the patched extension