### PR TITLE
OSC: add /browser/insertClap to insert a CLAP device by ID

### DIFF
--- a/src/main/java/de/mossgrabers/bitwig/framework/daw/BrowserImpl.java
+++ b/src/main/java/de/mossgrabers/bitwig/framework/daw/BrowserImpl.java
@@ -251,6 +251,24 @@ public class BrowserImpl extends AbstractBrowser
     }
 
 
+    /**
+     * Insert a CLAP device directly by its CLAP ID (e.g. "com.jmoss.dsp-lab"),
+     * bypassing the browser entirely. This reaches plug-ins that the popup
+     * browser's smart-collection column cannot (the "Plug-ins" collection is not
+     * populated in the insertion popup). Inserts at the end of the selected
+     * track's device chain, or after the cursor device if one exists.
+     *
+     * @param clapId The CLAP plugin ID
+     */
+    @Override
+    public void insertClapDevice (final String clapId)
+    {
+        final InsertionPoint insertionPoint = this.cursorDevice.exists ().get () ? this.cursorDevice.afterDeviceInsertionPoint () : this.cursorTrack.endOfDeviceChainInsertionPoint ();
+        if (insertionPoint != null)
+            insertionPoint.insertCLAPDevice (clapId);
+    }
+
+
     private void browse (final InsertionPoint insertionPoint)
     {
         this.stopBrowsing (false);

--- a/src/main/java/de/mossgrabers/controller/osc/module/BrowserModule.java
+++ b/src/main/java/de/mossgrabers/controller/osc/module/BrowserModule.java
@@ -81,6 +81,13 @@ public class BrowserModule extends AbstractModule
                     browser.insertBeforeCursorDevice ();
                 break;
 
+            case "insertClap":
+                // Insert a CLAP device directly by its ID (passed as the value),
+                // bypassing the browser. Reaches plug-ins the popup browser cannot.
+                if (value != null)
+                    browser.insertClapDevice (value.toString ());
+                break;
+
             case "commit":
                 browser.stopBrowsing (true);
                 break;

--- a/src/main/java/de/mossgrabers/framework/daw/IBrowser.java
+++ b/src/main/java/de/mossgrabers/framework/daw/IBrowser.java
@@ -144,6 +144,14 @@ public interface IBrowser extends IObserverManagement
 
 
     /**
+     * Insert a CLAP device directly by its CLAP ID, bypassing the browser.
+     *
+     * @param clapId The CLAP plugin ID (e.g. "com.jmoss.dsp-lab")
+     */
+    void insertClapDevice (String clapId);
+
+
+    /**
      * Stop browsing.
      *
      * @param commitSelection Commits the selection if true otherwise it is discarded.


### PR DESCRIPTION
## Summary

The OSC browser module can only insert devices via the popup browser (`insertAfterCursorDevice`), which does not expose Bitwig's **Plug-ins** collection — the collection where third-party CLAP/VST plug-ins live. As a result, CLAP plug-ins cannot currently be inserted over OSC (they don't appear in the popup browser's results, filters, or the smart-collection column when opened for device insertion).

Bitwig's `InsertionPoint` API provides `insertCLAPDevice(String)`, which inserts a CLAP plug-in directly by its ID without going through the browser at all. This PR wires that up.

## Changes

- `IBrowser.insertClapDevice(String)` + implementation in `BrowserImpl`, inserting after the cursor device (or at the end of the selected track's device chain when no device is selected).
- New OSC command **`/browser/insertClap`** that takes the CLAP ID as the OSC *value* (it contains dots, so it's passed as the argument rather than in the address path), e.g.:

  ```
  /browser/insertClap "com.example.my-synth"
  ```

## Testing

Built against extension-api v21 (Bitwig 6) with JDK 21 / Maven. Verified live: sending `/browser/insertClap "com.jmoss.dsp-lab"` inserts the CLAP instrument onto the selected track (confirmed the device loads and plays), where the popup-browser path could not reach it.

## Notes

The Bitwig controller API does not expose a way to *enumerate* installed CLAP plug-ins (`insertCLAPDevice` is the only CLAP-related method), so the caller needs to know the CLAP ID. That's easily obtained from the plug-in itself or Bitwig's plug-in index, so discovery is left to the OSC client.